### PR TITLE
Expose the cause of closing on a BufferedStream

### DIFF
--- a/src/main/java/io/axoniq/axonserver/connector/ResultStream.java
+++ b/src/main/java/io/axoniq/axonserver/connector/ResultStream.java
@@ -16,6 +16,7 @@
 
 package io.axoniq.axonserver.connector;
 
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -95,8 +96,21 @@ public interface ResultStream<T> extends AutoCloseable {
     /**
      * Indicates whether the current stream is closed for further reading. Note that this method will also return {@code
      * false} in case the stream is closed by the element provider, but there are still elements awaiting consumption.
+     * <p>
+     * Check {@link #getError()} to check whether the stream was closed because of an error
      *
      * @return {@code true} if the stream is closed for further reading, otherwise {@code false}
+     * @see #getError()
      */
     boolean isClosed();
+
+    /**
+     * Returns an optional containing the exception reported by the Server, if any.
+     * <p>
+     * Note that this method may return a non-empty response, even when {@link #isClosed()} returns {@code false}, or
+     * if there are messages available for processing.
+     *
+     * @return an optional containing the exception reported by the Server, if any.
+     */
+    Optional<Throwable> getError();
 }

--- a/src/main/java/io/axoniq/axonserver/connector/impl/FlowControlledBuffer.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/FlowControlledBuffer.java
@@ -74,6 +74,16 @@ public abstract class FlowControlledBuffer<T, R> extends FlowControlledStream<T,
     }
 
     /**
+     * Returns the error result, if any was recorded. This method may also yield a non-empty result when the buffer
+     * still contains messages for processing.
+     *
+     * @return the error result, if any was recorded, or else {@code null}
+     */
+    public Throwable getErrorResult() {
+        return errorResult.get();
+    }
+
+    /**
      * Try to retrieve an entry of type {@code T} from the buffer immediately. If none is present, {@code null} will be
      * returned.
      *

--- a/src/test/java/io/axoniq/axonserver/connector/impl/BufferedStreamTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/impl/BufferedStreamTest.java
@@ -1,0 +1,91 @@
+package io.axoniq.axonserver.connector.impl;
+
+import io.axoniq.axonserver.grpc.FlowControl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BufferedStreamTest {
+
+    private AbstractBufferedStream<String, String> testSubject;
+
+    @BeforeEach
+    void setUp() {
+        this.testSubject = new AbstractBufferedStream<String, String>("test", 100, 0) {
+
+            @Override
+            protected String buildFlowControlMessage(FlowControl flowControl) {
+                return null;
+            }
+
+            @Override
+            protected String terminalMessage() {
+                return "__terminal__";
+            }
+        };
+    }
+
+    @Test
+    void testBufferAndCloseStream() {
+        assertNull(testSubject.nextIfAvailable());
+
+        testSubject.onNext("First");
+        testSubject.onNext("Second");
+        testSubject.onCompleted();
+
+        assertEquals("First", testSubject.nextIfAvailable());
+        assertFalse(testSubject.isClosed());
+        assertEquals("Second", testSubject.nextIfAvailable());
+        assertTrue(testSubject.isClosed());
+    }
+
+    @Test
+    void testBufferAndCloseStreamWithError() {
+        assertNull(testSubject.nextIfAvailable());
+
+        testSubject.onNext("First");
+        testSubject.onNext("Second");
+        testSubject.onError(new RuntimeException("Faking an error"));
+
+        assertEquals("First", testSubject.nextIfAvailable());
+        assertFalse(testSubject.isClosed());
+        assertTrue(testSubject.getError().isPresent());
+        assertEquals("Second", testSubject.nextIfAvailable());
+        assertTrue(testSubject.isClosed());
+        assertTrue(testSubject.getError().isPresent());
+    }
+
+    @Test
+    void testDataAvailableHandlerTriggeredImmediatelyOnErroredBuffer() {
+        assertNull(testSubject.nextIfAvailable());
+
+        testSubject.onError(new RuntimeException("Faking an error"));
+
+        assertTrue(testSubject.isClosed());
+
+        AtomicBoolean triggered = new AtomicBoolean(false);
+        testSubject.onAvailable(() -> triggered.set(true));
+
+        assertTrue(triggered.get());
+    }
+
+    @Test
+    void testDataAvailableHandlerTriggeredImmediatelyOnClosedBuffer() {
+        assertNull(testSubject.nextIfAvailable());
+
+        testSubject.onCompleted();
+
+        assertTrue(testSubject.isClosed());
+
+        AtomicBoolean triggered = new AtomicBoolean(false);
+        testSubject.onAvailable(() -> triggered.set(true));
+
+        assertTrue(triggered.get());
+    }
+}


### PR DESCRIPTION
It was impossible for a client to get the root cause of a stream being closed, as the exception reported when closing a stream was not exposed. This commit adds a method to the ResultStream which exposes the reported error.