### PR TITLE
idle timeout support

### DIFF
--- a/src/main/java/io/axoniq/axonserver/connector/AxonServerConnectionFactory.java
+++ b/src/main/java/io/axoniq/axonserver/connector/AxonServerConnectionFactory.java
@@ -190,6 +190,9 @@ public class AxonServerConnectionFactory {
                 NettyChannelBuilder.forAddress(address.getHostName(), address.getGrpcPort())
         );
 
+        builder.keepAliveTime(0L, TimeUnit.SECONDS);
+        builder.idleTimeout(600L, TimeUnit.SECONDS);
+
         if (!suppressDownloadMessage) {
             builder.intercept(new DownloadInstructionInterceptor(System.out));
         }


### PR DESCRIPTION
considerations:
- command- and query-handlers need long-lasting/permanent connections to the axon-server
    - the underlying grpc-java framework has a idleTimeout which defaults to 30 min, suppressed by keep-alive
    - the underlying network infrastructure is not obligated to respect keep-alive intention
    - keepAliveTimeout semantics of axon-server-connector are about a single keep-alive,
the duration of keeping-alive can't be configured
- the reconnect facility is error-triggered, which would require axon-framework internal timers to trigger the error first of all