### PR TITLE
Ensure that error reading events for agggregate are propagated

### DIFF
--- a/src/main/java/io/axoniq/axonserver/connector/event/AggregateEventStream.java
+++ b/src/main/java/io/axoniq/axonserver/connector/event/AggregateEventStream.java
@@ -46,7 +46,7 @@ public interface AggregateEventStream {
      * available for reading.
      *
      * @return {@code true} if a message is available, or {@code false} if the stream has reached the end
-     * @throws StreamClosedException is the stream has been closed prematurely because of an error or on client request
+     * @throws StreamClosedException if the stream has been closed prematurely because of an error or on client request
      */
     boolean hasNext();
 
@@ -54,8 +54,8 @@ public interface AggregateEventStream {
      * Close this stream for further reading, notifying the provider of Events to stop streaming them. Any event already
      * emitted by the sender may still be consumed.
      * <p>
-     * Note that after calling {@code cancel}, {@link #hasNext()} may throw a StreamClosedException if the cancellation
-     * caused the stream to close before the last message was received.
+     * Note that after calling {@code cancel}, {@link #hasNext()} may throw a {@link StreamClosedException} if the
+     * cancellation caused the stream to close before the last message was received.
      */
     void cancel();
 

--- a/src/main/java/io/axoniq/axonserver/connector/event/AggregateEventStream.java
+++ b/src/main/java/io/axoniq/axonserver/connector/event/AggregateEventStream.java
@@ -46,12 +46,16 @@ public interface AggregateEventStream {
      * available for reading.
      *
      * @return {@code true} if a message is available, or {@code false} if the stream has reached the end
+     * @throws StreamClosedException is the stream has been closed prematurely because of an error or on client request
      */
     boolean hasNext();
 
     /**
      * Close this stream for further reading, notifying the provider of Events to stop streaming them. Any event already
      * emitted by the sender may still be consumed.
+     * <p>
+     * Note that after calling {@code cancel}, {@link #hasNext()} may throw a StreamClosedException if the cancellation
+     * caused the stream to close before the last message was received.
      */
     void cancel();
 

--- a/src/main/java/io/axoniq/axonserver/connector/event/impl/BufferedAggregateEventStream.java
+++ b/src/main/java/io/axoniq/axonserver/connector/event/impl/BufferedAggregateEventStream.java
@@ -18,6 +18,7 @@ package io.axoniq.axonserver.connector.event.impl;
 
 import io.axoniq.axonserver.connector.event.AggregateEventStream;
 import io.axoniq.axonserver.connector.impl.FlowControlledBuffer;
+import io.axoniq.axonserver.connector.impl.StreamClosedException;
 import io.axoniq.axonserver.grpc.FlowControl;
 import io.axoniq.axonserver.grpc.event.Event;
 import io.axoniq.axonserver.grpc.event.GetAggregateEventsRequest;
@@ -72,6 +73,12 @@ public class BufferedAggregateEventStream
             cancel();
             Thread.currentThread().interrupt();
             return false;
+        }
+        if (peeked == null) {
+            Throwable errorResult = getErrorResult();
+            if (errorResult != null) {
+                throw new StreamClosedException(errorResult);
+            }
         }
         return peeked != null;
     }

--- a/src/test/java/io/axoniq/axonserver/connector/event/EventHandlingTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/event/EventHandlingTest.java
@@ -143,8 +143,12 @@ class EventHandlingTest extends AbstractAxonServerIntegrationTest {
 
         AggregateEventStream stream = eventChannel.openAggregateStream("aggregate1");
         stream.cancel();
-        while (stream.hasNext()) {
-            Assertions.assertNotEquals(199, stream.next().getAggregateSequenceNumber());
+        try {
+            while (stream.hasNext()) {
+                Assertions.assertNotEquals(199, stream.next().getAggregateSequenceNumber());
+            }
+        } catch (StreamClosedException e) {
+            // that's ok, because we're reading from a stream we have closed ourselves.
         }
     }
 

--- a/src/test/java/io/axoniq/axonserver/connector/event/impl/BufferedAggregateEventStreamTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/event/impl/BufferedAggregateEventStreamTest.java
@@ -2,13 +2,17 @@ package io.axoniq.axonserver.connector.event.impl;
 
 import io.axoniq.axonserver.connector.impl.StreamClosedException;
 import io.axoniq.axonserver.grpc.event.Event;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Test class validationg the {@link BufferedAggregateEventStream}.
+ *
+ * @author Allard Buijze
+ */
 class BufferedAggregateEventStreamTest {
 
     private BufferedAggregateEventStream testSubject;
@@ -22,8 +26,7 @@ class BufferedAggregateEventStreamTest {
     void testEventStreamPropagatesErrorOnHasNext() {
         testSubject.onError(new RuntimeException("Mock"));
 
-        Assertions.assertThrows(StreamClosedException.class,
-                                () -> testSubject.hasNext());
+        assertThrows(StreamClosedException.class, () -> testSubject.hasNext());
     }
 
     @Test
@@ -36,7 +39,6 @@ class BufferedAggregateEventStreamTest {
         assertEquals(Event.getDefaultInstance(), testSubject.next());
         assertTrue(testSubject.hasNext());
         assertEquals(Event.getDefaultInstance(), testSubject.next());
-        Assertions.assertThrows(StreamClosedException.class,
-                                () -> testSubject.hasNext());
+        assertThrows(StreamClosedException.class, () -> testSubject.hasNext());
     }
 }

--- a/src/test/java/io/axoniq/axonserver/connector/event/impl/BufferedAggregateEventStreamTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/event/impl/BufferedAggregateEventStreamTest.java
@@ -1,0 +1,42 @@
+package io.axoniq.axonserver.connector.event.impl;
+
+import io.axoniq.axonserver.connector.impl.StreamClosedException;
+import io.axoniq.axonserver.grpc.event.Event;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+class BufferedAggregateEventStreamTest {
+
+    private BufferedAggregateEventStream testSubject;
+
+    @BeforeEach
+    void setUp() {
+        testSubject = new BufferedAggregateEventStream(10);
+    }
+
+    @Test
+    void testEventStreamPropagatesErrorOnHasNext() {
+        testSubject.onError(new RuntimeException("Mock"));
+
+        Assertions.assertThrows(StreamClosedException.class,
+                                () -> testSubject.hasNext());
+    }
+
+    @Test
+    void testEventStreamPropagatesErrorOnHasNextAfterReadingAvailableEvents() throws InterruptedException {
+        testSubject.onNext(Event.getDefaultInstance());
+        testSubject.onNext(Event.getDefaultInstance());
+        testSubject.onError(new RuntimeException("Mock"));
+
+        assertTrue(testSubject.hasNext());
+        assertEquals(Event.getDefaultInstance(), testSubject.next());
+        assertTrue(testSubject.hasNext());
+        assertEquals(Event.getDefaultInstance(), testSubject.next());
+        Assertions.assertThrows(StreamClosedException.class,
+                                () -> testSubject.hasNext());
+    }
+}


### PR DESCRIPTION
This commit fixes an issue where errors reported while reading events for an aggregate aren't reported to the consumer. Instead, the consumer receives an empty or incomplete stream, based on which it could make false assumptions.