### PR TITLE
Client reconnect when stream is completed unexpectedly by the server. 

### DIFF
--- a/src/main/java/io/axoniq/axonserver/connector/impl/AbstractIncomingInstructionStream.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/AbstractIncomingInstructionStream.java
@@ -33,6 +33,8 @@ import java.util.function.Consumer;
  *
  * @param <IN>  the type of instructions received by this stream
  * @param <OUT> the type of instructions returned by this stream
+ * @author Allard Buijze
+ * @since 4.4
  */
 public abstract class AbstractIncomingInstructionStream<IN, OUT> extends FlowControlledStream<IN, OUT> {
 

--- a/src/main/java/io/axoniq/axonserver/connector/impl/AbstractIncomingInstructionStream.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/AbstractIncomingInstructionStream.java
@@ -114,6 +114,9 @@ public abstract class AbstractIncomingInstructionStream<IN, OUT> extends FlowCon
     public void onCompleted() {
         logger.debug("Stream completed from server side");
         if (unregisterOutboundStream(instructionsForPlatform)) {
+            logger.debug("Instruction stream disconnected. Scheduling reconnect");
+            Throwable t = new StreamUnexpectedlyCompletedException("Stream unexpectedly completed by server");
+            disconnectHandler.accept(t);
             instructionsForPlatform.onCompleted();
         }
     }

--- a/src/main/java/io/axoniq/axonserver/connector/impl/StreamUnexpectedlyCompletedException.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/StreamUnexpectedlyCompletedException.java
@@ -8,7 +8,6 @@ package io.axoniq.axonserver.connector.impl;
  */
 public class StreamUnexpectedlyCompletedException extends RuntimeException {
 
-
     /**
      * Constructs a new instance of {@link StreamUnexpectedlyCompletedException}.
      */

--- a/src/main/java/io/axoniq/axonserver/connector/impl/StreamUnexpectedlyCompletedException.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/StreamUnexpectedlyCompletedException.java
@@ -1,0 +1,27 @@
+package io.axoniq.axonserver.connector.impl;
+
+/**
+ * A {@link RuntimeException} to throw if a stream is completed unexpectedly.
+ *
+ * @author Sara Pellegrini
+ * @since 4.4.3
+ */
+public class StreamUnexpectedlyCompletedException extends RuntimeException {
+
+
+    /**
+     * Constructs a new instance of {@link StreamUnexpectedlyCompletedException}.
+     */
+    public StreamUnexpectedlyCompletedException() {
+    }
+
+    /**
+     * Constructs a new instance of {@link StreamUnexpectedlyCompletedException} with a detailed description of the
+     * cause of the exception
+     *
+     * @param message the message describing the cause of the exception.
+     */
+    public StreamUnexpectedlyCompletedException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/io/axoniq/axonserver/connector/impl/AbstractIncomingInstructionStreamTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/impl/AbstractIncomingInstructionStreamTest.java
@@ -1,0 +1,84 @@
+package io.axoniq.axonserver.connector.impl;
+
+import io.axoniq.axonserver.connector.InstructionHandler;
+import io.axoniq.axonserver.grpc.FlowControl;
+import io.axoniq.axonserver.grpc.InstructionAck;
+import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.*;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Test class validating the {{@link AbstractIncomingInstructionStream}}.
+ *
+ * @author Steven van Beelen
+ */
+class AbstractIncomingInstructionStreamTest {
+
+    private static final String CLIENT_ID = "clientId";
+    private static final int PERMITS = 100;
+    private static final int PERMITS_BATCH = 100;
+
+    @Test
+    void testOnCompleted() {
+        AtomicReference<Throwable> disconnectHandlerThrowable = new AtomicReference<>();
+        AbstractIncomingInstructionStream<Object, Object> testSubject = new TestAbstractIncomingInstructionStreamImpl(
+                CLIENT_ID, PERMITS, PERMITS_BATCH, disconnectHandlerThrowable::set, true
+        );
+        //noinspection unchecked
+        ClientCallStreamObserver<Object> mockedClientCallStreamObserver = mock(ClientCallStreamObserver.class);
+
+        // Given
+        testSubject.beforeStart(mockedClientCallStreamObserver);
+        // When
+        testSubject.onCompleted();
+        // Then
+        assertTrue(disconnectHandlerThrowable.get() instanceof StreamUnexpectedlyCompletedException);
+        verify(mockedClientCallStreamObserver).onCompleted();
+    }
+
+    private static class TestAbstractIncomingInstructionStreamImpl
+            extends AbstractIncomingInstructionStream<Object, Object> {
+
+        private final boolean unregisterOutboundStreamResponse;
+
+        public TestAbstractIncomingInstructionStreamImpl(String clientId,
+                                                         int permits,
+                                                         int permitsBatch,
+                                                         Consumer<Throwable> disconnectHandler,
+                                                         boolean unregisterOutboundStreamResponse) {
+            super(clientId, permits, permitsBatch, disconnectHandler);
+            this.unregisterOutboundStreamResponse = unregisterOutboundStreamResponse;
+        }
+
+        @Override
+        protected Object buildAckMessage(InstructionAck ack) {
+            return null;
+        }
+
+        @Override
+        protected String getInstructionId(Object instruction) {
+            return null;
+        }
+
+        @Override
+        protected InstructionHandler<Object, Object> getHandler(Object msgIn) {
+            return null;
+        }
+
+        @Override
+        protected boolean unregisterOutboundStream(StreamObserver<Object> expected) {
+            return this.unregisterOutboundStreamResponse;
+        }
+
+        @Override
+        protected Object buildFlowControlMessage(FlowControl flowControl) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Copy of #26, but just containing the fixes and not the accidental addition of master.

Adds the invocation of the `disconnectHandler` if `onCompleted` had `AbstractIncomingInstructionStream#unregisterOutboundStream` return `true`.