### PR TITLE
Fix subscribe when disconnected

### DIFF
--- a/src/main/java/io/axoniq/axonserver/connector/impl/AxonServerManagedChannel.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/AxonServerManagedChannel.java
@@ -426,7 +426,7 @@ public class AxonServerManagedChannel extends ManagedChannel {
 
         @Override
         public void sendMessage(REQ message) {
-            throw new StatusRuntimeException(Status.UNAVAILABLE);
+            // ignore these messages. The returning stream has already given an error
         }
     }
 }

--- a/src/main/java/io/axoniq/axonserver/connector/impl/AxonServerManagedChannel.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/AxonServerManagedChannel.java
@@ -27,7 +27,6 @@ import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -104,8 +103,9 @@ public class AxonServerManagedChannel extends ManagedChannel {
     private ManagedChannel connectChannel() {
         ManagedChannel connection = null;
         for (ServerAddress nodeInfo : routingServers) {
-            ManagedChannel candidate = connectionFactory.apply(nodeInfo, context);
+            ManagedChannel candidate = null;
             try {
+                candidate = connectionFactory.apply(nodeInfo, context);
                 PlatformServiceGrpc.PlatformServiceBlockingStub stub =
                         PlatformServiceGrpc.newBlockingStub(candidate)
                                            .withDeadlineAfter(connectTimeout, TimeUnit.MILLISECONDS);
@@ -139,9 +139,9 @@ public class AxonServerManagedChannel extends ManagedChannel {
                 suppressErrors.set(false);
                 lastConnectException.set(null);
                 break;
-            } catch (StatusRuntimeException sre) {
+            } catch (Exception sre) {
                 lastConnectException.set(sre);
-                shutdownNow(candidate);
+                doIfNotNull(candidate, this::shutdownNow);
                 if (!suppressErrors.getAndSet(true)) {
                     logger.warn("Connecting to AxonServer node [{}] failed.", nodeInfo, sre);
                 } else {
@@ -348,6 +348,7 @@ public class AxonServerManagedChannel extends ManagedChannel {
                 scheduleConnectionCheck(reconnectInterval);
             }
         } catch (Exception e) {
+            lastConnectException.set(e);
             doIfNotNull(newConnection, ManagedChannel::shutdown);
             if (allowReschedule) {
                 logger.info("Failed to get connection to AxonServer. Scheduling a reconnect in {}ms",

--- a/src/test/java/io/axoniq/axonserver/connector/AbstractAxonServerIntegrationTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/AbstractAxonServerIntegrationTest.java
@@ -95,6 +95,7 @@ public abstract class AbstractAxonServerIntegrationTest {
         for (Toxic toxic : axonServerProxy.toxics().getAll()) {
             toxic.remove();
         }
+        axonServerProxy.enable();
         AxonServerUtils.purgeEventsFromAxonServer(axonServerHttpPort.getHostName(), axonServerHttpPort.getGrpcPort());
     }
 

--- a/src/test/java/io/axoniq/axonserver/connector/command/CommandChannelIntegrationTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/command/CommandChannelIntegrationTest.java
@@ -40,13 +40,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class CommandChannelTest extends AbstractAxonServerIntegrationTest {
+class CommandChannelIntegrationTest extends AbstractAxonServerIntegrationTest {
 
     private AxonServerConnectionFactory connectionFactory1;
     private AxonServerConnection connection1;
     private AxonServerConnectionFactory connectionFactory2;
     private AxonServerConnection connection2;
-    private static final Logger logger = LoggerFactory.getLogger(CommandChannelTest.class);
+    private static final Logger logger = LoggerFactory.getLogger(CommandChannelIntegrationTest.class);
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/io/axoniq/axonserver/connector/command/CommandChannelTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/command/CommandChannelTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2020. AxonIQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.axoniq.axonserver.connector.command;
+
+import io.axoniq.axonserver.connector.AxonServerConnection;
+import io.axoniq.axonserver.connector.AxonServerConnectionFactory;
+import io.axoniq.axonserver.connector.Registration;
+import io.axoniq.axonserver.connector.impl.ServerAddress;
+import io.axoniq.axonserver.grpc.command.CommandResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static io.axoniq.axonserver.connector.impl.ObjectUtils.silently;
+import static io.axoniq.axonserver.connector.testutils.AssertUtils.assertWithin;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CommandChannelTest {
+
+    private AxonServerConnectionFactory connectionFactory1;
+    private AxonServerConnection connection1;
+
+    @BeforeEach
+    void setUp() {
+        connectionFactory1 = AxonServerConnectionFactory.forClient(getClass().getSimpleName(),
+                                                                   "client1")
+                                                        .routingServers(new ServerAddress("127:0.0.1"))
+                                                        .forceReconnectViaRoutingServers(false)
+                                                        .reconnectInterval(500, TimeUnit.MILLISECONDS)
+                                                        .build();
+        connection1 = connectionFactory1.connect("default");
+    }
+
+    @AfterEach
+    void tearDown() {
+        silently(connectionFactory1, AxonServerConnectionFactory::shutdown);
+    }
+
+    @Test
+    void testSubscribeWithMalformedUrl() throws InterruptedException {
+        CommandChannel commandChannel = connection1.commandChannel();
+
+        assertFalse(connection1.isConnected());
+        assertWithin(1, TimeUnit.SECONDS, ()-> assertTrue(connection1.isConnectionFailed()));
+
+        Registration result = commandChannel
+                .registerCommandHandler(r -> CompletableFuture.completedFuture(CommandResponse.getDefaultInstance()), 100, "test");
+        assertNotNull(result);
+    }
+}

--- a/src/test/java/io/axoniq/axonserver/connector/event/EventHandlingIntegrationTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/event/EventHandlingIntegrationTest.java
@@ -50,7 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class EventHandlingTest extends AbstractAxonServerIntegrationTest {
+class EventHandlingIntegrationTest extends AbstractAxonServerIntegrationTest {
 
     private AxonServerConnectionFactory client1;
     private AxonServerConnection connection1;

--- a/src/test/java/io/axoniq/axonserver/connector/impl/AxonServerManagedChannelIntegrationTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/impl/AxonServerManagedChannelIntegrationTest.java
@@ -43,7 +43,7 @@ import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
-class AxonServerManagedChannelTest extends AbstractAxonServerIntegrationTest {
+class AxonServerManagedChannelIntegrationTest extends AbstractAxonServerIntegrationTest {
 
     private final List<ServerAddress> connectAttempts = new CopyOnWriteArrayList<>();
     private AxonServerManagedChannel testSubject;

--- a/src/test/java/io/axoniq/axonserver/connector/impl/ControlChannelIntegrationTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/impl/ControlChannelIntegrationTest.java
@@ -54,10 +54,10 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-class ControlChannelTest extends AbstractAxonServerIntegrationTest {
+class ControlChannelIntegrationTest extends AbstractAxonServerIntegrationTest {
 
     private AxonServerConnectionFactory client;
-    private static final Logger logger = LoggerFactory.getLogger(ControlChannelTest.class);
+    private static final Logger logger = LoggerFactory.getLogger(ControlChannelIntegrationTest.class);
 
     @AfterEach
     void tearDown() {

--- a/src/test/java/io/axoniq/axonserver/connector/query/QueryChannelIntegrationTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/query/QueryChannelIntegrationTest.java
@@ -52,7 +52,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-class QueryChannelTest extends AbstractAxonServerIntegrationTest {
+class QueryChannelIntegrationTest extends AbstractAxonServerIntegrationTest {
 
     private static final CompletableFuture<Void> COMPLETED_FUTURE = CompletableFuture.completedFuture(null);
 
@@ -60,7 +60,7 @@ class QueryChannelTest extends AbstractAxonServerIntegrationTest {
     private AxonServerConnection connection1;
     private AxonServerConnectionFactory connectionFactory2;
     private AxonServerConnection connection2;
-    private static final Logger logger = LoggerFactory.getLogger(QueryChannelTest.class);
+    private static final Logger logger = LoggerFactory.getLogger(QueryChannelIntegrationTest.class);
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
Some exceptions (mainly those not extending from StatusRuntimeException) would not put the Connector in a state where it recognizes the connection is in an error state. As a result, it would allow calls to be triggered from the various Connector Channels, which then resulted in exceptions.

This change ensures that failed connect attempts are recognized as such and will prevent calls from being sent.

When calls _are_ sent, they now behave exactly the same way as calls using the grpc library's own ManagedChannel should behave. That means messages towards the server are ignored and calls immediately (exceptionally) completed with a Status exception.