### PR TITLE
Connector connection recovery improvement

### DIFF
--- a/src/main/java/io/axoniq/axonserver/connector/command/impl/CommandChannelImpl.java
+++ b/src/main/java/io/axoniq/axonserver/connector/command/impl/CommandChannelImpl.java
@@ -431,8 +431,8 @@ public class CommandChannelImpl extends AbstractAxonServerChannel implements Com
                                      int permits,
                                      int permitsBatch,
                                      Consumer<Throwable> disconnectHandler,
-                                     Consumer<CallStreamObserver<CommandProviderOutbound>> onStartHandler) {
-            super(clientId, permits, permitsBatch, disconnectHandler, onStartHandler);
+                                     Consumer<CallStreamObserver<CommandProviderOutbound>> beforeStartHandler) {
+            super(clientId, permits, permitsBatch, disconnectHandler, beforeStartHandler);
         }
 
         @Override

--- a/src/main/java/io/axoniq/axonserver/connector/impl/AbstractIncomingInstructionStream.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/AbstractIncomingInstructionStream.java
@@ -51,27 +51,27 @@ public abstract class AbstractIncomingInstructionStream<IN, OUT> extends FlowCon
 
     private final Consumer<Throwable> disconnectHandler;
 
-    private final Consumer<CallStreamObserver<OUT>> onStartHandler;
+    private final Consumer<CallStreamObserver<OUT>> beforeStartHandler;
     private CallStreamObserver<OUT> instructionsForPlatform;
 
     /**
      * Construct an {@link AbstractIncomingInstructionStream}.
      *
-     * @param clientId          the client identifier whom initiated this instruction stream
-     * @param permits           the number of permits this stream should receive
-     * @param permitsBatch      the number of permits to be consumed prior to requesting new permits
-     * @param disconnectHandler a {@link Consumer} of {@link Throwable} invoked when this stream errors out
-     * @param onStartHandler    the handler to call when the upstream connection is available. Note that the call has
-     *                          not started yet at this point.
+     * @param clientId           the client identifier whom initiated this instruction stream
+     * @param permits            the number of permits this stream should receive
+     * @param permitsBatch       the number of permits to be consumed prior to requesting new permits
+     * @param disconnectHandler  a {@link Consumer} of {@link Throwable} invoked when this stream errors out
+     * @param beforeStartHandler the handler to invoke when the upstream connection is available. Note that the gRPC
+     *                           call has not started yet at this point.
      */
     protected AbstractIncomingInstructionStream(String clientId,
                                                 int permits,
                                                 int permitsBatch,
                                                 Consumer<Throwable> disconnectHandler,
-                                                Consumer<CallStreamObserver<OUT>> onStartHandler) {
+                                                Consumer<CallStreamObserver<OUT>> beforeStartHandler) {
         super(clientId, permits, permitsBatch);
         this.disconnectHandler = disconnectHandler;
-        this.onStartHandler = onStartHandler;
+        this.beforeStartHandler = beforeStartHandler;
     }
 
     @Override
@@ -144,7 +144,7 @@ public abstract class AbstractIncomingInstructionStream<IN, OUT> extends FlowCon
         SynchronizedRequestStream<OUT> synchronizedRequestStream = new SynchronizedRequestStream<>(requestStream);
         super.beforeStart(synchronizedRequestStream);
         this.instructionsForPlatform = synchronizedRequestStream;
-        this.onStartHandler.accept(getInstructionsForPlatform());
+        this.beforeStartHandler.accept(getInstructionsForPlatform());
     }
 
     /**

--- a/src/main/java/io/axoniq/axonserver/connector/impl/AxonServerManagedChannel.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/AxonServerManagedChannel.java
@@ -139,13 +139,13 @@ public class AxonServerManagedChannel extends ManagedChannel {
                 suppressErrors.set(false);
                 lastConnectException.set(null);
                 break;
-            } catch (Exception sre) {
-                lastConnectException.set(sre);
+            } catch (Exception e) {
+                lastConnectException.set(e);
                 doIfNotNull(candidate, this::shutdownNow);
                 if (!suppressErrors.getAndSet(true)) {
-                    logger.warn("Connecting to AxonServer node [{}] failed.", nodeInfo, sre);
+                    logger.warn("Connecting to AxonServer node [{}] failed.", nodeInfo, e);
                 } else {
-                    logger.warn("Connecting to AxonServer node [{}] failed: {}", nodeInfo, sre.getMessage());
+                    logger.warn("Connecting to AxonServer node [{}] failed: {}", nodeInfo, e.getMessage());
                 }
             }
         }

--- a/src/main/java/io/axoniq/axonserver/connector/impl/ControlChannelImpl.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/ControlChannelImpl.java
@@ -256,6 +256,8 @@ public class ControlChannelImpl extends AbstractAxonServerChannel implements Con
             CallStreamObserver<PlatformInboundInstruction> outbound = instructionDispatcher.get();
             if (outbound != null && outbound.isReady()) {
                 infoSupplies.forEach(info -> doIfNotNull(info.get(), this::sendProcessorInfo));
+            } else {
+                logger.debug("Not sending processor info for context '{}'. Channel not ready...", context);
             }
             executor.schedule(this::sendScheduledProcessorInfo, processorInfoUpdateFrequency, TimeUnit.MILLISECONDS);
         }

--- a/src/main/java/io/axoniq/axonserver/connector/impl/ControlChannelImpl.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/ControlChannelImpl.java
@@ -298,6 +298,9 @@ public class ControlChannelImpl extends AbstractAxonServerChannel implements Con
             }
             try {
                 dispatcher.onNext(instruction);
+                if (!hasLength(instructionId)) {
+                    result.complete(InstructionAck.newBuilder().setSuccess(true).build());
+                }
             } catch (Exception e) {
                 awaitingAck.remove(instructionId);
                 result.completeExceptionally(e);

--- a/src/main/java/io/axoniq/axonserver/connector/impl/ControlChannelImpl.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/ControlChannelImpl.java
@@ -253,7 +253,10 @@ public class ControlChannelImpl extends AbstractAxonServerChannel implements Con
                 sendScheduledProcessorInfo();
             }
         } else {
-            infoSupplies.forEach(info -> doIfNotNull(info.get(), this::sendProcessorInfo));
+            CallStreamObserver<PlatformInboundInstruction> outbound = instructionDispatcher.get();
+            if (outbound != null && outbound.isReady()) {
+                infoSupplies.forEach(info -> doIfNotNull(info.get(), this::sendProcessorInfo));
+            }
             executor.schedule(this::sendScheduledProcessorInfo, processorInfoUpdateFrequency, TimeUnit.MILLISECONDS);
         }
     }

--- a/src/test/java/io/axoniq/axonserver/connector/AbstractAxonServerIntegrationTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/AbstractAxonServerIntegrationTest.java
@@ -77,9 +77,11 @@ public abstract class AbstractAxonServerIntegrationTest {
     protected static ServerAddress axonServerAddress;
     private static ServerAddress axonServerHttpPort;
     protected String axonServerVersion;
+    private static OkHttpClient client;
 
     @BeforeAll
     static void initialize() throws IOException {
+        client = new OkHttpClient();
         axonServerAddress = new ServerAddress(toxiProxyContainer.getContainerIpAddress(), toxiProxyContainer.getMappedPort(8124));
         axonServerHttpPort = new ServerAddress(axonServerContainer.getContainerIpAddress(), axonServerContainer.getMappedPort(8024));
         ToxiproxyClient client = new ToxiproxyClient(toxiProxyContainer.getContainerIpAddress(), toxiProxyContainer.getMappedPort(8474));
@@ -108,7 +110,6 @@ public abstract class AbstractAxonServerIntegrationTest {
     }
 
     protected JsonElement sendToAxonServer(BiFunction<Request.Builder, RequestBody, Request.Builder> method, String path) throws IOException {
-        OkHttpClient client = new OkHttpClient();
         Call call = client.newCall(method.apply(new Request.Builder()
                                                         .url("http://" + axonServerContainer.getContainerIpAddress() + ":" + axonServerContainer.getMappedPort(8024) + path),
                                                 Util.EMPTY_REQUEST)
@@ -122,6 +123,7 @@ public abstract class AbstractAxonServerIntegrationTest {
         } else {
             read = GSON.fromJson(new InputStreamReader(result.body().byteStream()), JsonElement.class);
         }
+        result.close();
         return read;
     }
 

--- a/src/test/java/io/axoniq/axonserver/connector/impl/AbstractIncomingInstructionStreamTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/impl/AbstractIncomingInstructionStreamTest.java
@@ -69,9 +69,9 @@ class AbstractIncomingInstructionStreamTest {
                                                          int permits,
                                                          int permitsBatch,
                                                          Consumer<Throwable> disconnectHandler,
-                                                         Consumer<CallStreamObserver<Object>> onStartHandler,
+                                                         Consumer<CallStreamObserver<Object>> beforeStartHandler,
                                                          boolean unregisterOutboundStreamResponse) {
-            super(clientId, permits, permitsBatch, disconnectHandler, onStartHandler);
+            super(clientId, permits, permitsBatch, disconnectHandler, beforeStartHandler);
             this.unregisterOutboundStreamResponse = unregisterOutboundStreamResponse;
         }
 

--- a/src/test/java/io/axoniq/axonserver/connector/impl/ControlChannelIntegrationTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/impl/ControlChannelIntegrationTest.java
@@ -23,8 +23,10 @@ import io.axoniq.axonserver.connector.AbstractAxonServerIntegrationTest;
 import io.axoniq.axonserver.connector.AxonServerConnection;
 import io.axoniq.axonserver.connector.AxonServerConnectionFactory;
 import io.axoniq.axonserver.connector.ReplyChannel;
+import io.axoniq.axonserver.connector.control.ControlChannel;
 import io.axoniq.axonserver.connector.control.ProcessorInstructionHandler;
 import io.axoniq.axonserver.connector.event.EventStream;
+import io.axoniq.axonserver.grpc.InstructionAck;
 import io.axoniq.axonserver.grpc.control.EventProcessorInfo;
 import io.axoniq.axonserver.grpc.control.PlatformInboundInstruction;
 import io.axoniq.axonserver.grpc.control.PlatformOutboundInstruction;
@@ -140,6 +142,18 @@ class ControlChannelIntegrationTest extends AbstractAxonServerIntegrationTest {
 
         assertWithin(1, TimeUnit.SECONDS, () -> assertTrue(buffer.isClosed(), "Expected Event Streams to be closed by reconnect request"));
 
+    }
+
+    @Test
+    public void instructionsWithoutInstructionIdAreCompletedImmediately() {
+        client = AxonServerConnectionFactory.forClient(getClass().getSimpleName())
+                                            .routingServers(axonServerAddress)
+                                            .build();
+        ControlChannel controlChannel = client.connect("default")
+                                              .controlChannel();
+
+        CompletableFuture<InstructionAck> result = controlChannel.sendInstruction(PlatformInboundInstruction.getDefaultInstance());
+        assertTrue(result.isDone());
     }
 
     @Test

--- a/src/test/java/io/axoniq/axonserver/connector/impl/ControlChannelIntegrationTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/impl/ControlChannelIntegrationTest.java
@@ -159,6 +159,7 @@ class ControlChannelIntegrationTest extends AbstractAxonServerIntegrationTest {
     @Test
     void testPauseAndStartInstructionIsPickedUpByHandler() throws Exception {
         client = AxonServerConnectionFactory.forClient(getClass().getSimpleName())
+                                            .processorInfoUpdateFrequency(500, TimeUnit.MILLISECONDS)
                                             .routingServers(axonServerAddress)
                                             .build();
         AxonServerConnection connection1 = client.connect("default");
@@ -184,6 +185,7 @@ class ControlChannelIntegrationTest extends AbstractAxonServerIntegrationTest {
     @Test
     void testSplitAndMergeInstructionIsPickedUpByHandler() throws TimeoutException, InterruptedException {
         client = AxonServerConnectionFactory.forClient(getClass().getSimpleName())
+                                            .processorInfoUpdateFrequency(500, TimeUnit.MILLISECONDS)
                                             .routingServers(axonServerAddress)
                                             .build();
         AxonServerConnection connection1 = client.connect("default");


### PR DESCRIPTION
This PR addresses a race condition that can occur when setting up a connection that fails in a very short period of time. In such a case, the connector could believe it still has a valid connection with Axon Server.

Logging has been improved to include the name of context for which the message applies.