### PR TITLE
Prevent eager initialization of Command and Query channels

### DIFF
--- a/src/main/java/io/axoniq/axonserver/connector/command/impl/CommandChannelImpl.java
+++ b/src/main/java/io/axoniq/axonserver/connector/command/impl/CommandChannelImpl.java
@@ -40,6 +40,7 @@ import io.axoniq.axonserver.grpc.command.CommandResponse;
 import io.axoniq.axonserver.grpc.command.CommandServiceGrpc;
 import io.axoniq.axonserver.grpc.command.CommandSubscription;
 import io.axoniq.axonserver.grpc.control.ClientIdentification;
+import io.grpc.Status;
 import io.grpc.stub.CallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import io.netty.util.internal.OutOfDirectMemoryError;
@@ -187,7 +188,7 @@ public class CommandChannelImpl extends AbstractAxonServerChannel implements Com
         instructionsAwaitingAck.keySet().forEach(
                 k -> doIfNotNull(instructionsAwaitingAck.remove(k), f -> f.completeExceptionally(error))
         );
-        scheduleReconnect();
+        scheduleReconnect(Status.fromThrowable(error));
     }
 
     @Override

--- a/src/main/java/io/axoniq/axonserver/connector/event/impl/EventChannelImpl.java
+++ b/src/main/java/io/axoniq/axonserver/connector/event/impl/EventChannelImpl.java
@@ -97,7 +97,7 @@ public class EventChannelImpl extends AbstractAxonServerChannel implements Event
     }
 
     @Override
-    public boolean isConnected() {
+    public boolean isReady() {
         return true;
     }
 

--- a/src/main/java/io/axoniq/axonserver/connector/impl/AbstractAxonServerChannel.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/AbstractAxonServerChannel.java
@@ -111,9 +111,11 @@ public abstract class AbstractAxonServerChannel {
     public abstract void disconnect();
 
     /**
-     * Validate whether this channel is connected with AxonServer.
+     * Validate whether this channel has all required streams connected with AxonServer. If the state of the channel
+     * does not require any active streams, it is considered ready and will return {@code true}.
      *
-     * @return {@code true} if this channel is connected with AxonServer, {@code false} otherwise
+     * @return {@code true} if this channel is connected with AxonServer or does not require any active connections,
+     * {@code false} otherwise
      */
-    public abstract boolean isConnected();
+    public abstract boolean isReady();
 }

--- a/src/main/java/io/axoniq/axonserver/connector/impl/AbstractAxonServerChannel.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/AbstractAxonServerChannel.java
@@ -17,6 +17,7 @@
 package io.axoniq.axonserver.connector.impl;
 
 import io.grpc.ConnectivityState;
+import io.grpc.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,43 +38,58 @@ public abstract class AbstractAxonServerChannel {
     /**
      * Instantiate an {@link AbstractAxonServerChannel}.
      *
-     * @param executor                 a {@link ScheduledExecutorService} used to invoke {@link #scheduleReconnect()} in
-     *                                 a separate thread
-     * @param axonServerManagedChannel the {@link AxonServerManagedChannel} used to validate whether {@link
-     *                                 #scheduleReconnect()} is succeeded or should be tried again
+     * @param executor                 a {@link ScheduledExecutorService} used to schedule reconnections
+     * @param axonServerManagedChannel the {@link AxonServerManagedChannel} used to vconnect to AxonServer
      */
-    public AbstractAxonServerChannel(ScheduledExecutorService executor,
-                                     AxonServerManagedChannel axonServerManagedChannel) {
+    protected AbstractAxonServerChannel(ScheduledExecutorService executor,
+                                        AxonServerManagedChannel axonServerManagedChannel) {
         this.executor = executor;
         this.channel = axonServerManagedChannel;
     }
 
     /**
-     * Schedule an attempt to reconnect with AxonServer.
+     * Schedule an attempt to reconnect with AxonServer. Depending on the {@code disconnectReason}, the reconnect
+     * attempt will be executed within 500ms or 5000ms.
+     *
+     * @param disconnectReason The reason why the previous connection failed.
      */
-    protected void scheduleReconnect() {
-        scheduleReconnect(false);
+    protected void scheduleReconnect(Status disconnectReason) {
+        switch (disconnectReason.getCode()) {
+            case NOT_FOUND:
+            case PERMISSION_DENIED:
+            case UNIMPLEMENTED:
+            case UNAUTHENTICATED:
+            case FAILED_PRECONDITION:
+            case INVALID_ARGUMENT:
+            case RESOURCE_EXHAUSTED:
+                scheduleReconnect(5000);
+                break;
+            default:
+                scheduleReconnect(500);
+                break;
+        }
     }
+
 
     /**
      * Schedule an immediate attempt to reconnect with AxonServer.
      */
     protected void scheduleImmediateReconnect() {
         logger.debug("Scheduling immediate reconnect");
-        scheduleReconnect(true);
+        scheduleReconnect(0);
     }
 
-    private void scheduleReconnect(boolean immediate) {
+    private void scheduleReconnect(int delay) {
         try {
             executor.schedule(() -> {
-                ConnectivityState connectivityState = channel.getState(immediate);
+                ConnectivityState connectivityState = channel.getState(delay == 0);
                 if (connectivityState == ConnectivityState.READY) {
                     connect();
                 } else {
                     logger.debug("No connection to AxonServer available. Scheduling next attempt in 500ms");
-                    scheduleReconnect(false);
+                    scheduleReconnect(500);
                 }
-            }, immediate ? 0 : 500, TimeUnit.MILLISECONDS);
+            }, delay, TimeUnit.MILLISECONDS);
         } catch (RejectedExecutionException e) {
             logger.info("Ignoring reconnect request, as connector is being shut down.");
         }

--- a/src/main/java/io/axoniq/axonserver/connector/impl/ContextConnection.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/ContextConnection.java
@@ -97,10 +97,10 @@ public class ContextConnection implements AxonServerConnection {
     @Override
     public boolean isReady() {
         return isConnected()
-                && Optional.ofNullable(commandChannel.get()).map(CommandChannelImpl::isConnected).orElse(true)
-                && Optional.ofNullable(queryChannel.get()).map(QueryChannelImpl::isConnected).orElse(true)
-                && Optional.ofNullable(eventChannel.get()).map(EventChannelImpl::isConnected).orElse(true)
-                && controlChannel.isConnected();
+                && Optional.ofNullable(commandChannel.get()).map(CommandChannelImpl::isReady).orElse(true)
+                && Optional.ofNullable(queryChannel.get()).map(QueryChannelImpl::isReady).orElse(true)
+                && Optional.ofNullable(eventChannel.get()).map(EventChannelImpl::isReady).orElse(true)
+                && controlChannel.isReady();
     }
 
     @Override
@@ -166,7 +166,7 @@ public class ContextConnection implements AxonServerConnection {
     }
 
     private <T extends AbstractAxonServerChannel> T ensureConnected(T channel) {
-        if (!channel.isConnected()) {
+        if (!channel.isReady()) {
             ConnectivityState state = connection.getState(true);
             if (state != ConnectivityState.SHUTDOWN && state != ConnectivityState.TRANSIENT_FAILURE) {
                 try {

--- a/src/main/java/io/axoniq/axonserver/connector/impl/ControlChannelImpl.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/ControlChannelImpl.java
@@ -143,7 +143,7 @@ public class ControlChannelImpl extends AbstractAxonServerChannel implements Con
     }
 
     private CompletableFuture<InstructionAck> sendHeartBeat() {
-        if (!isConnected()) {
+        if (!isReady()) {
             return CompletableFuture.completedFuture(null);
         }
         PlatformInboundInstruction heartbeatMessage =
@@ -198,7 +198,7 @@ public class ControlChannelImpl extends AbstractAxonServerChannel implements Con
     }
 
     @Override
-    public void reconnect() {
+    public synchronized void reconnect() {
         doIfNotNull(instructionDispatcher.getAndSet(null), StreamObserver::onCompleted);
         scheduleImmediateReconnect();
     }
@@ -217,7 +217,7 @@ public class ControlChannelImpl extends AbstractAxonServerChannel implements Con
     }
 
     @Override
-    public void disconnect() {
+    public synchronized void disconnect() {
         heartbeatMonitor.disableHeartbeat();
         StreamObserver<PlatformInboundInstruction> dispatcher = instructionDispatcher.getAndSet(null);
         if (dispatcher != null) {
@@ -317,7 +317,7 @@ public class ControlChannelImpl extends AbstractAxonServerChannel implements Con
     }
 
     @Override
-    public boolean isConnected() {
+    public boolean isReady() {
         return instructionDispatcher.get() != null;
     }
 

--- a/src/main/java/io/axoniq/axonserver/connector/impl/ControlChannelImpl.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/ControlChannelImpl.java
@@ -31,6 +31,7 @@ import io.axoniq.axonserver.grpc.control.Heartbeat;
 import io.axoniq.axonserver.grpc.control.PlatformInboundInstruction;
 import io.axoniq.axonserver.grpc.control.PlatformOutboundInstruction;
 import io.axoniq.axonserver.grpc.control.PlatformServiceGrpc;
+import io.grpc.Status;
 import io.grpc.stub.CallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
@@ -204,7 +205,7 @@ public class ControlChannelImpl extends AbstractAxonServerChannel implements Con
 
     private void handleDisconnect(Throwable cause) {
         failOpenInstructions(cause);
-        scheduleReconnect();
+        scheduleReconnect(Status.fromThrowable(cause));
     }
 
     private void failOpenInstructions(Throwable cause) {

--- a/src/main/java/io/axoniq/axonserver/connector/query/impl/QueryChannelImpl.java
+++ b/src/main/java/io/axoniq/axonserver/connector/query/impl/QueryChannelImpl.java
@@ -49,6 +49,7 @@ import io.axoniq.axonserver.grpc.query.QueryUpdateComplete;
 import io.axoniq.axonserver.grpc.query.SubscriptionQuery;
 import io.axoniq.axonserver.grpc.query.SubscriptionQueryRequest;
 import io.axoniq.axonserver.grpc.query.SubscriptionQueryResponse;
+import io.grpc.Status;
 import io.grpc.stub.CallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
@@ -208,7 +209,7 @@ public class QueryChannelImpl extends AbstractAxonServerChannel implements Query
                 clientIdentification.getClientId(),
                 permits,
                 permitsBatch,
-                e -> scheduleReconnect(),
+                e -> scheduleReconnect(Status.fromThrowable(e)),
                 this::registerOutboundStream
         );
 

--- a/src/main/java/io/axoniq/axonserver/connector/query/impl/QueryChannelImpl.java
+++ b/src/main/java/io/axoniq/axonserver/connector/query/impl/QueryChannelImpl.java
@@ -82,7 +82,7 @@ public class QueryChannelImpl extends AbstractAxonServerChannel implements Query
     private static final QueryResponse TERMINAL = QueryResponse.newBuilder().setErrorCode("__TERMINAL__").build();
 
     private final AtomicReference<CallStreamObserver<QueryProviderOutbound>> outboundQueryStream = new AtomicReference<>();
-    private final Set<QueryDefinition> supportedQueries = new CopyOnWriteArraySet<>();
+    private final Map<QueryDefinition, AtomicInteger> supportedQueries = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, Set<QueryHandler>> queryHandlers = new ConcurrentHashMap<>();
     private final ConcurrentMap<Enum<?>, InstructionHandler<QueryProviderInbound, QueryProviderOutbound>> instructionHandlers = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, CompletableFuture<Void>> instructions = new ConcurrentHashMap<>();
@@ -129,7 +129,7 @@ public class QueryChannelImpl extends AbstractAxonServerChannel implements Query
 
     private void handleAck(QueryProviderInbound query, ReplyChannel<QueryProviderOutbound> result) {
         String instructionId = query.getAck().getInstructionId();
-        CompletableFuture<Void> future = instructions.get(instructionId);
+        CompletableFuture<Void> future = instructions.remove(instructionId);
         if (future != null) {
             if (query.getAck().getSuccess()) {
                 future.complete(null);
@@ -200,7 +200,13 @@ public class QueryChannelImpl extends AbstractAxonServerChannel implements Query
     }
 
     @Override
-    public synchronized void connect() {
+    public void connect() {
+        if (!queryHandlers.isEmpty()) {
+            doConnectQueryStream();
+        }
+    }
+
+    private synchronized void doConnectQueryStream() {
         if (outboundQueryStream.get() != null) {
             logger.debug("QueryChannel for context '{}' is already connected", context);
             return;
@@ -209,19 +215,29 @@ public class QueryChannelImpl extends AbstractAxonServerChannel implements Query
                 clientIdentification.getClientId(),
                 permits,
                 permitsBatch,
-                e -> scheduleReconnect(Status.fromThrowable(e)),
+                this::onConnectionError,
                 this::registerOutboundStream
         );
 
         //noinspection ResultOfMethodCallIgnored
         queryServiceStub.openStream(responseObserver);
-        StreamObserver<QueryProviderOutbound> newValue = responseObserver.getInstructionsForPlatform();
+        CallStreamObserver<QueryProviderOutbound> newValue = responseObserver.getInstructionsForPlatform();
 
-        supportedQueries.forEach(k -> newValue.onNext(
+        supportedQueries.keySet().forEach(k -> newValue.onNext(
                 buildSubscribeMessage(k.getQueryName(), k.getResultType(), UUID.randomUUID().toString())
         ));
         responseObserver.enableFlowControl();
-        logger.info("QueryChannel for context '{}' connected, {} registrations resubscribed", context, queryHandlers.size());
+        if (outboundQueryStream.get() == newValue) {
+            logger.info("QueryChannel for context '{}' connected, {} registrations resubscribed", context, queryHandlers.size());
+        }
+    }
+
+    private void onConnectionError(Throwable error) {
+        logger.info("Error on QueryChannel for context {}", context, error);
+        instructions.keySet().forEach(
+                k -> doIfNotNull(instructions.remove(k), f -> f.completeExceptionally(error))
+        );
+        scheduleReconnect(Status.fromThrowable(error));
     }
 
     private void registerOutboundStream(CallStreamObserver<QueryProviderOutbound> upstream) {
@@ -247,10 +263,15 @@ public class QueryChannelImpl extends AbstractAxonServerChannel implements Query
     public Registration registerQueryHandler(QueryHandler handler, QueryDefinition... queryDefinitions) {
         CompletableFuture<Void> subscriptionResult = CompletableFuture.completedFuture(null);
         synchronized (queryHandlerMonitor) {
+            if (queryHandlers.isEmpty()) {
+                doConnectQueryStream();
+            }
+
             for (QueryDefinition queryDefinition : queryDefinitions) {
                 this.queryHandlers.computeIfAbsent(queryDefinition.getQueryName(), k -> new CopyOnWriteArraySet<>())
                                   .add(handler);
-                boolean firstRegistration = supportedQueries.add(queryDefinition);
+                boolean firstRegistration = supportedQueries.computeIfAbsent(queryDefinition, k -> new AtomicInteger())
+                                                            .getAndIncrement() == 0;
                 if (firstRegistration) {
                     QueryProviderOutbound subscribeMessage = buildSubscribeMessage(queryDefinition.getQueryName(),
                                                                                    queryDefinition.getResultType(),
@@ -271,30 +292,26 @@ public class QueryChannelImpl extends AbstractAxonServerChannel implements Query
                         result = CompletableFuture.allOf(result, sendUnsubscribe(def));
                         logger.debug("Unregistered handlers for query '{}' in context '{}'", def, context);
                     }
+                    supportedQueries.computeIfPresent(def, (qd, counter) -> counter.decrementAndGet() == 0 ? null : counter);
                 }
                 return result;
             }
         });
     }
 
-    private CompletableFuture<Void> sendInstruction(QueryProviderOutbound subscribeMessage) {
-        CompletableFuture<Void> future = new CompletableFuture<>();
-        doIfNotNull(outboundQueryStream.get(),
-                    s -> {
-                        if (hasLength(subscribeMessage.getInstructionId())) {
-                            instructions.put(subscribeMessage.getInstructionId(), future);
-                        } else {
-                            future.complete(null);
-                        }
-                        try {
-                            s.onNext(subscribeMessage);
-                        } catch (Exception e) {
-                            instructions.remove(subscribeMessage.getInstructionId(), future);
-                            future.completeExceptionally(e);
-                        }
-                    })
-                .orElse(() -> future.complete(null));
-        return future;
+    private CompletableFuture<Void> sendInstruction(QueryProviderOutbound instruction) {
+        CompletableFuture<Void> ack = new CompletableFuture<>();
+        if (hasLength(instruction.getInstructionId())) {
+            instructions.put(instruction.getInstructionId(), ack);
+            ack.whenComplete((r, e) -> instructions.remove(instruction.getInstructionId(), ack));
+        } else {
+            ack.complete(null);
+        }
+        doIfNotNull(outboundQueryStream.get(), s -> s.onNext(instruction))
+                .orElse(() -> ack.completeExceptionally(new AxonServerException(ErrorCategory.INSTRUCTION_ACK_ERROR,
+                                                                                "Unable to send instruction: no connection to AxonServer",
+                                                                                clientIdentification.getClientId())));
+        return ack;
     }
 
     private CompletableFuture<Void> sendUnsubscribe(QueryDefinition queryDefinition) {
@@ -387,7 +404,7 @@ public class QueryChannelImpl extends AbstractAxonServerChannel implements Query
     }
 
     @Override
-    public void disconnect() {
+    public synchronized void disconnect() {
         doIfNotNull(outboundQueryStream.getAndSet(null), StreamObserver::onCompleted);
         cancelAllSubscriptionQueries();
     }
@@ -400,7 +417,8 @@ public class QueryChannelImpl extends AbstractAxonServerChannel implements Query
 
     @Override
     public CompletableFuture<Void> prepareDisconnect() {
-        CompletableFuture<Void> future = supportedQueries.stream()
+        CompletableFuture<Void> future = supportedQueries.keySet()
+                                                         .stream()
                                                          .map(this::sendUnsubscribe)
                                                          .reduce(CompletableFuture::allOf)
                                                          .orElseGet(() -> CompletableFuture.completedFuture(null));
@@ -413,8 +431,8 @@ public class QueryChannelImpl extends AbstractAxonServerChannel implements Query
     }
 
     @Override
-    public boolean isConnected() {
-        return outboundQueryStream.get() != null;
+    public boolean isReady() {
+        return outboundQueryStream.get() != null || queryHandlers.isEmpty();
     }
 
     private void doHandleQuery(QueryProviderInbound query, ReplyChannel<QueryResponse> responseHandler) {

--- a/src/test/java/io/axoniq/axonserver/connector/command/CommandChannelIntegrationTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/command/CommandChannelIntegrationTest.java
@@ -19,12 +19,15 @@ package io.axoniq.axonserver.connector.command;
 import io.axoniq.axonserver.connector.AbstractAxonServerIntegrationTest;
 import io.axoniq.axonserver.connector.AxonServerConnection;
 import io.axoniq.axonserver.connector.AxonServerConnectionFactory;
+import io.axoniq.axonserver.connector.AxonServerException;
 import io.axoniq.axonserver.connector.ErrorCategory;
 import io.axoniq.axonserver.connector.Registration;
+import io.axoniq.axonserver.connector.command.impl.CommandChannelImpl;
 import io.axoniq.axonserver.grpc.command.Command;
 import io.axoniq.axonserver.grpc.command.CommandResponse;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,6 +43,7 @@ import static io.axoniq.axonserver.connector.testutils.AssertUtils.assertWithin;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CommandChannelIntegrationTest extends AbstractAxonServerIntegrationTest {
@@ -137,6 +141,34 @@ class CommandChannelIntegrationTest extends AbstractAxonServerIntegrationTest {
         CommandResponse commandResponse = result.get(1, TimeUnit.SECONDS);
         assertEquals("", commandResponse.getErrorMessage().getMessage());
     }
+
+    @RepeatedTest(10)
+    void testQueryChannelConsideredConnectedWhenNoHandlersSubscribed() throws IOException, TimeoutException, InterruptedException {
+        CommandChannelImpl commandChannel = (CommandChannelImpl) connection1.commandChannel();
+        // just to make sure that no attempt was made to connect, since there are no handlers
+        assertTrue(commandChannel.isReady());
+
+        // make sure no real connection can be set up
+        axonServerProxy.disable();
+        assertWithin(1, TimeUnit.SECONDS, () -> assertFalse(connection1.isConnected()));
+
+        assertTrue(commandChannel.isReady());
+        assertFalse(connection1.isConnected());
+
+        Registration registration = commandChannel.registerCommandHandler(c -> CompletableFuture.completedFuture(null),
+                                                                          100, "TestCommand");
+        AxonServerException exception = assertThrows(AxonServerException.class, () -> registration.awaitAck(1, TimeUnit.SECONDS));
+        assertEquals(ErrorCategory.INSTRUCTION_ACK_ERROR, exception.getErrorCategory());
+
+        // because of the attempt to set up a connection, it may need a few milliseconds to discover that's not possible
+        assertWithin(1, TimeUnit.SECONDS, () -> assertFalse(commandChannel.isReady()));
+
+        axonServerProxy.enable();
+
+        // verify connection is established
+        assertWithin(2, TimeUnit.SECONDS, () -> assertTrue(commandChannel.isReady()));
+    }
+
 
     @Test
     void testDispatchCommandOnDisconnectReturnsError() throws Exception {

--- a/src/test/java/io/axoniq/axonserver/connector/query/QueryChannelIntegrationTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/query/QueryChannelIntegrationTest.java
@@ -20,10 +20,12 @@ import com.google.protobuf.ByteString;
 import io.axoniq.axonserver.connector.AbstractAxonServerIntegrationTest;
 import io.axoniq.axonserver.connector.AxonServerConnection;
 import io.axoniq.axonserver.connector.AxonServerConnectionFactory;
+import io.axoniq.axonserver.connector.AxonServerException;
 import io.axoniq.axonserver.connector.ErrorCategory;
 import io.axoniq.axonserver.connector.Registration;
 import io.axoniq.axonserver.connector.ReplyChannel;
 import io.axoniq.axonserver.connector.ResultStream;
+import io.axoniq.axonserver.connector.query.impl.QueryChannelImpl;
 import io.axoniq.axonserver.grpc.SerializedObject;
 import io.axoniq.axonserver.grpc.query.QueryRequest;
 import io.axoniq.axonserver.grpc.query.QueryResponse;
@@ -37,6 +39,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -45,7 +48,13 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static io.axoniq.axonserver.connector.testutils.AssertUtils.assertWithin;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class QueryChannelIntegrationTest extends AbstractAxonServerIntegrationTest {
 
@@ -103,7 +112,7 @@ class QueryChannelIntegrationTest extends AbstractAxonServerIntegrationTest {
 
         axonServerProxy.enable();
 
-        assertWithin(2, TimeUnit.SECONDS, () -> assertTrue(connection1.isReady()));
+        assertWithin(5, TimeUnit.SECONDS, () -> assertTrue(connection1.isReady()));
 
         ResultStream<QueryResponse> result2 = connection2.queryChannel().query(QueryRequest.newBuilder().setQuery("testQuery").build());
         QueryResponse actual = result2.nextIfAvailable(1, TimeUnit.SECONDS);
@@ -143,6 +152,33 @@ class QueryChannelIntegrationTest extends AbstractAxonServerIntegrationTest {
                 assertThrows(IllegalArgumentException.class,
                              () -> queryChannel.subscriptionQuery(queryRequest, serializedObject, 5, 1));
         assertEquals("QueryRequest must contain message identifier.", exception.getMessage());
+    }
+
+    @RepeatedTest(10)
+    void testQueryChannelConsideredConnectedWhenNoHandlersSubscribed() throws IOException, TimeoutException, InterruptedException {
+        QueryChannelImpl queryChannel = (QueryChannelImpl) connection1.queryChannel();
+        // just to make sure that no attempt was made to connect, since there are no handlers
+        assertTrue(queryChannel.isReady());
+
+        // make sure no real connection can be set up
+        axonServerProxy.disable();
+        assertWithin(1, TimeUnit.SECONDS, () -> assertFalse(connection1.isConnected()));
+
+        assertTrue(queryChannel.isReady());
+        assertFalse(connection1.isConnected());
+
+        Registration registration = queryChannel.registerQueryHandler((q, r) -> r.complete(),
+                                                                      new QueryDefinition("test", String.class));
+        AxonServerException exception = assertThrows(AxonServerException.class, () -> registration.awaitAck(1, TimeUnit.SECONDS));
+        assertEquals(ErrorCategory.INSTRUCTION_ACK_ERROR, exception.getErrorCategory());
+
+        // because of the attempt to set up a connection, it may need a few milliseconds to discover that's not possible
+        assertWithin(1, TimeUnit.SECONDS, () -> assertFalse(queryChannel.isReady()));
+
+        axonServerProxy.enable();
+
+        // verify connection is established
+        assertWithin(2, TimeUnit.SECONDS, () -> assertTrue(queryChannel.isReady()));
     }
 
     @Test
@@ -229,7 +265,9 @@ class QueryChannelIntegrationTest extends AbstractAxonServerIntegrationTest {
                 };
             }
         }, new QueryDefinition("testQuery", "testResult"))
-            .awaitAck(1, TimeUnit.SECONDS);
+                    .awaitAck(1, TimeUnit.SECONDS);
+
+        Thread.sleep(100);
 
         SubscriptionQueryResult subscriptionQuery = connection2.queryChannel().subscriptionQuery(QueryRequest.newBuilder()
                                                                                                              .setMessageIdentifier(subscriptionId)


### PR DESCRIPTION
The connector would eagerly connect the command and query handling streams, even when a component would only access the channels for sending messages. This caused the channel to fail to connect when the application does not have the required authorizations to subscribe to messages.

This PR makes the creation of the stream dependent on whether handlers are subscribed. When no handers are subscribed, request to connect() are ignored.

The `isConnected()` method has been renamed to `isReady()` and returns `true` in case no connection is required.

Resolves #40.