### PR TITLE
Aggregate sequence number validation 

### DIFF
--- a/src/main/java/io/axoniq/axonserver/connector/event/impl/BufferedAggregateEventStream.java
+++ b/src/main/java/io/axoniq/axonserver/connector/event/impl/BufferedAggregateEventStream.java
@@ -114,7 +114,7 @@ public class BufferedAggregateEventStream
             super.onNext(event);
             lastReceivedEvent.set(event);
         } else {
-            String message = String.format("Invalid sequence number for aggregate %s. Received: %d, expected: %d",
+            String message = String.format("Invalid sequence number for aggregate with identifier [%s]. Received seqNo: %d, expected seqNo: %d",
                                            event.getAggregateIdentifier(),
                                            event.getAggregateSequenceNumber(),
                                            prevEvent.getAggregateSequenceNumber() + 1);

--- a/src/main/java/io/axoniq/axonserver/connector/event/impl/BufferedAggregateEventStream.java
+++ b/src/main/java/io/axoniq/axonserver/connector/event/impl/BufferedAggregateEventStream.java
@@ -22,6 +22,7 @@ import io.axoniq.axonserver.connector.impl.StreamClosedException;
 import io.axoniq.axonserver.grpc.FlowControl;
 import io.axoniq.axonserver.grpc.event.Event;
 import io.axoniq.axonserver.grpc.event.GetAggregateEventsRequest;
+import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -118,7 +119,12 @@ public class BufferedAggregateEventStream
                                            event.getAggregateSequenceNumber(),
                                            prevEvent.getAggregateSequenceNumber() + 1);
             logger.error(message);
-            this.onError(new RuntimeException(message));
+            RuntimeException invalidAggregateEventStreamException = new RuntimeException(message);
+            StreamObserver<GetAggregateEventsRequest> outboundStream = outboundStream();
+            if (outboundStream != null) {
+                outboundStream.onError(invalidAggregateEventStreamException);
+            }
+            this.onError(invalidAggregateEventStreamException);
         }
     }
 }

--- a/src/main/java/io/axoniq/axonserver/connector/event/impl/BufferedAggregateEventStream.java
+++ b/src/main/java/io/axoniq/axonserver/connector/event/impl/BufferedAggregateEventStream.java
@@ -22,6 +22,8 @@ import io.axoniq.axonserver.connector.impl.StreamClosedException;
 import io.axoniq.axonserver.grpc.FlowControl;
 import io.axoniq.axonserver.grpc.event.Event;
 import io.axoniq.axonserver.grpc.event.GetAggregateEventsRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.atomic.AtomicReference;
 

--- a/src/test/java/io/axoniq/axonserver/connector/event/impl/BufferedAggregateEventStreamTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/event/impl/BufferedAggregateEventStreamTest.java
@@ -32,11 +32,21 @@ class BufferedAggregateEventStreamTest {
     @Test
     void testEventStreamPropagatesErrorOnHasNextAfterReadingAvailableEvents() throws InterruptedException {
         testSubject.onNext(Event.getDefaultInstance());
-        testSubject.onNext(Event.getDefaultInstance());
+        testSubject.onNext(Event.newBuilder().setAggregateSequenceNumber(1).build());
         testSubject.onError(new RuntimeException("Mock"));
 
         assertTrue(testSubject.hasNext());
         assertEquals(Event.getDefaultInstance(), testSubject.next());
+        assertTrue(testSubject.hasNext());
+        assertEquals(Event.newBuilder().setAggregateSequenceNumber(1).build(), testSubject.next());
+        assertThrows(StreamClosedException.class, () -> testSubject.hasNext());
+    }
+
+    @Test
+    void testEventStreamErrorOnInvalidAggregateSequenceNumber() throws InterruptedException {
+        testSubject.onNext(Event.getDefaultInstance());
+        testSubject.onNext(Event.getDefaultInstance());
+
         assertTrue(testSubject.hasNext());
         assertEquals(Event.getDefaultInstance(), testSubject.next());
         assertThrows(StreamClosedException.class, () -> testSubject.hasNext());

--- a/src/test/java/io/axoniq/axonserver/connector/event/impl/BufferedAggregateEventStreamTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/event/impl/BufferedAggregateEventStreamTest.java
@@ -2,11 +2,14 @@ package io.axoniq.axonserver.connector.event.impl;
 
 import io.axoniq.axonserver.connector.impl.StreamClosedException;
 import io.axoniq.axonserver.grpc.event.Event;
+import io.axoniq.axonserver.grpc.event.GetAggregateEventsRequest;
+import io.grpc.stub.ClientCallStreamObserver;
 import org.junit.jupiter.api.*;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 /**
  * Test class validationg the {@link BufferedAggregateEventStream}.
@@ -44,11 +47,14 @@ class BufferedAggregateEventStreamTest {
 
     @Test
     void testEventStreamErrorOnInvalidAggregateSequenceNumber() throws InterruptedException {
+        ClientCallStreamObserver clientCallStreamObserverMock = mock(ClientCallStreamObserver.class);
+        testSubject.beforeStart(clientCallStreamObserverMock);
         testSubject.onNext(Event.getDefaultInstance());
         testSubject.onNext(Event.getDefaultInstance());
 
         assertTrue(testSubject.hasNext());
         assertEquals(Event.getDefaultInstance(), testSubject.next());
+        verify(clientCallStreamObserverMock).onError(any(RuntimeException.class));
         assertThrows(StreamClosedException.class, () -> testSubject.hasNext());
     }
 }


### PR DESCRIPTION
Validates that events are received in the correct order, without any gap, checking if the aggregateSequenceNumbers are sequential.