### PR TITLE
Added grpc-level flow control to all streaming calls

### DIFF
--- a/src/main/java/io/axoniq/axonserver/connector/event/impl/BufferedAggregateEventStream.java
+++ b/src/main/java/io/axoniq/axonserver/connector/event/impl/BufferedAggregateEventStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020. AxonIQ
+ * Copyright (c) 2021. AxonIQ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,11 +51,23 @@ public class BufferedAggregateEventStream
 
     /**
      * Constructs a {@link BufferedAggregateEventStream} with the given {@code bufferSize}.
+     * <p>
+     * The permits will be replenished using batches of 1/8th of the given {@code bufferSize}, unless the buffer is
+     * small than 8 items, in which case permits are replenished individually, as items are consumed from the buffer.
      *
      * @param bufferSize the buffer size of the aggregate event stream
      */
     public BufferedAggregateEventStream(int bufferSize) {
-        super("unused", bufferSize, 0);
+        this(bufferSize, bufferSize >= 8 ? (bufferSize / 8) : 1);
+    }
+
+    /**
+     * Constructs a {@link BufferedAggregateEventStream} with the given {@code bufferSize}.
+     *
+     * @param bufferSize the buffer size of the aggregate event stream
+     */
+    public BufferedAggregateEventStream(int bufferSize, int refillBatch) {
+        super("unused", bufferSize, refillBatch);
     }
 
     @Override

--- a/src/main/java/io/axoniq/axonserver/connector/event/impl/BufferedAggregateEventStream.java
+++ b/src/main/java/io/axoniq/axonserver/connector/event/impl/BufferedAggregateEventStream.java
@@ -43,22 +43,11 @@ public class BufferedAggregateEventStream
     private Event peeked;
 
     /**
-     * Constructs a {@link BufferedAggregateEventStream} with a buffer size of {@link Integer#MAX_VALUE}.
+     * Constructs a {@link BufferedAggregateEventStream} with a buffer size of {@code 512} and a {@code refillBatch}
+     * of 16.
      */
     public BufferedAggregateEventStream() {
-        this(Integer.MAX_VALUE);
-    }
-
-    /**
-     * Constructs a {@link BufferedAggregateEventStream} with the given {@code bufferSize}.
-     * <p>
-     * The permits will be replenished using batches of 1/8th of the given {@code bufferSize}, unless the buffer is
-     * smaller than 8 items, in which case permits are replenished individually, as items are consumed from the buffer.
-     *
-     * @param bufferSize the buffer size of the aggregate event stream
-     */
-    public BufferedAggregateEventStream(int bufferSize) {
-        this(bufferSize, bufferSize >= 8 ? (bufferSize / 8) : 1);
+        this(512, 16);
     }
 
     /**
@@ -110,7 +99,7 @@ public class BufferedAggregateEventStream
 
     @Override
     protected GetAggregateEventsRequest buildFlowControlMessage(FlowControl flowControl) {
-        // no flow control available on this request
+        // no app-level flow control available on this request
         return null;
     }
 

--- a/src/main/java/io/axoniq/axonserver/connector/event/impl/BufferedAggregateEventStream.java
+++ b/src/main/java/io/axoniq/axonserver/connector/event/impl/BufferedAggregateEventStream.java
@@ -53,7 +53,7 @@ public class BufferedAggregateEventStream
      * Constructs a {@link BufferedAggregateEventStream} with the given {@code bufferSize}.
      * <p>
      * The permits will be replenished using batches of 1/8th of the given {@code bufferSize}, unless the buffer is
-     * small than 8 items, in which case permits are replenished individually, as items are consumed from the buffer.
+     * smaller than 8 items, in which case permits are replenished individually, as items are consumed from the buffer.
      *
      * @param bufferSize the buffer size of the aggregate event stream
      */

--- a/src/main/java/io/axoniq/axonserver/connector/event/impl/EventChannelImpl.java
+++ b/src/main/java/io/axoniq/axonserver/connector/event/impl/EventChannelImpl.java
@@ -54,7 +54,7 @@ import java.util.concurrent.ScheduledExecutorService;
 /**
  * {@link EventChannel} implementation, serving as the event connection between AxonServer and a client application.
  */
-public class EventChannelImpl extends AbstractAxonServerChannel implements EventChannel {
+public class EventChannelImpl extends AbstractAxonServerChannel<Void> implements EventChannel {
 
     private static final ReadHighestSequenceNrResponse UNKNOWN_HIGHEST_SEQ =
             ReadHighestSequenceNrResponse.newBuilder().setToSequenceNr(-1).build();

--- a/src/main/java/io/axoniq/axonserver/connector/event/impl/EventChannelImpl.java
+++ b/src/main/java/io/axoniq/axonserver/connector/event/impl/EventChannelImpl.java
@@ -215,7 +215,7 @@ public class EventChannelImpl extends AbstractAxonServerChannel<Void> implements
                                               long initialSequence,
                                               long maxSequence,
                                               int maxResults) {
-        BufferedAggregateEventStream buffer = new BufferedAggregateEventStream(1024);
+        BufferedAggregateEventStream buffer = new BufferedAggregateEventStream();
         eventStore.listAggregateSnapshots(GetAggregateSnapshotsRequest.newBuilder()
                                                                       .setInitialSequence(initialSequence)
                                                                       .setMaxResults(maxResults)
@@ -249,7 +249,7 @@ public class EventChannelImpl extends AbstractAxonServerChannel<Void> implements
     }
 
     private AggregateEventStream doGetAggregateStream(GetAggregateEventsRequest request) {
-        BufferedAggregateEventStream buffer = new BufferedAggregateEventStream(1024);
+        BufferedAggregateEventStream buffer = new BufferedAggregateEventStream();
         eventStore.listAggregateEvents(request, buffer);
         return buffer;
     }

--- a/src/main/java/io/axoniq/axonserver/connector/event/impl/EventChannelImpl.java
+++ b/src/main/java/io/axoniq/axonserver/connector/event/impl/EventChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020. AxonIQ
+ * Copyright (c) 2021. AxonIQ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -215,7 +215,7 @@ public class EventChannelImpl extends AbstractAxonServerChannel implements Event
                                               long initialSequence,
                                               long maxSequence,
                                               int maxResults) {
-        BufferedAggregateEventStream buffer = new BufferedAggregateEventStream(maxResults);
+        BufferedAggregateEventStream buffer = new BufferedAggregateEventStream(1024);
         eventStore.listAggregateSnapshots(GetAggregateSnapshotsRequest.newBuilder()
                                                                       .setInitialSequence(initialSequence)
                                                                       .setMaxResults(maxResults)
@@ -249,7 +249,7 @@ public class EventChannelImpl extends AbstractAxonServerChannel implements Event
     }
 
     private AggregateEventStream doGetAggregateStream(GetAggregateEventsRequest request) {
-        BufferedAggregateEventStream buffer = new BufferedAggregateEventStream();
+        BufferedAggregateEventStream buffer = new BufferedAggregateEventStream(1024);
         eventStore.listAggregateEvents(request, buffer);
         return buffer;
     }

--- a/src/main/java/io/axoniq/axonserver/connector/impl/AssertUtils.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/AssertUtils.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021. AxonIQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.axoniq.axonserver.connector.impl;
+
+/**
+ * Utility class to perform assertion on method parameters
+ */
+public class AssertUtils {
+
+    /**
+     * Assert that the given {@code condition} is true, or otherwise throws an {@link IllegalArgumentException} with
+     * given {@code message}.
+     *
+     * @param condition The condition to validate
+     * @param message   The message in the exception
+     */
+    public static void assertParameter(boolean condition, String message) {
+        if (!condition) {
+            throw new IllegalArgumentException(message);
+        }
+    }
+}

--- a/src/main/java/io/axoniq/axonserver/connector/impl/AssertUtils.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/AssertUtils.java
@@ -17,7 +17,7 @@
 package io.axoniq.axonserver.connector.impl;
 
 /**
- * Utility class to perform assertion on method parameters
+ * Utility class to perform assertion on method parameters.
  */
 public class AssertUtils {
 

--- a/src/main/java/io/axoniq/axonserver/connector/impl/AssertUtils.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/AssertUtils.java
@@ -21,6 +21,9 @@ package io.axoniq.axonserver.connector.impl;
  */
 public class AssertUtils {
 
+    private AssertUtils() {
+    }
+
     /**
      * Assert that the given {@code condition} is true, or otherwise throws an {@link IllegalArgumentException} with
      * given {@code message}.

--- a/src/main/java/io/axoniq/axonserver/connector/impl/AssertUtils.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/AssertUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021. AxonIQ
+ * Copyright (c) 2020-2021. AxonIQ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,9 @@ package io.axoniq.axonserver.connector.impl;
 
 /**
  * Utility class to perform assertion on method parameters.
+ *
+ * @author Allard Buijze
+ * @since 4.5
  */
 public class AssertUtils {
 

--- a/src/main/java/io/axoniq/axonserver/connector/impl/ControlChannelImpl.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/ControlChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020. AxonIQ
+ * Copyright (c) 2021. AxonIQ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -273,7 +273,7 @@ public class ControlChannelImpl extends AbstractAxonServerChannel<PlatformInboun
         public PlatformOutboundInstructionHandler(String clientId,
                                                   Consumer<Throwable> disconnectHandler,
                                                   Consumer<CallStreamObserver<PlatformInboundInstruction>> beforeStartHandler) {
-            super(clientId, 0, 0, disconnectHandler, beforeStartHandler);
+            super(clientId, 64, 8, disconnectHandler, beforeStartHandler);
         }
 
         @Override

--- a/src/main/java/io/axoniq/axonserver/connector/impl/SynchronizedRequestStream.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/SynchronizedRequestStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020. AxonIQ
+ * Copyright (c) 2021. AxonIQ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,6 +77,11 @@ public class SynchronizedRequestStream<T> extends ClientCallStreamObserver<T> {
     @Override
     public void onNext(T value) {
         inLock(() -> delegate.onNext(value));
+    }
+
+    @Override
+    public void disableAutoRequestWithInitial(int request) {
+        delegate.disableAutoRequestWithInitial(request);
     }
 
     @Override

--- a/src/main/java/io/axoniq/axonserver/connector/query/impl/QueryChannelImpl.java
+++ b/src/main/java/io/axoniq/axonserver/connector/query/impl/QueryChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020. AxonIQ
+ * Copyright (c) 2021. AxonIQ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -307,7 +307,7 @@ public class QueryChannelImpl extends AbstractAxonServerChannel<QueryProviderOut
     @Override
     public ResultStream<QueryResponse> query(QueryRequest query) {
         AbstractBufferedStream<QueryResponse, QueryRequest> results = new AbstractBufferedStream<QueryResponse, QueryRequest>(
-                clientIdentification.getClientId(), Integer.MAX_VALUE, 0
+                clientIdentification.getClientId(), 32, 8
         ) {
 
             @Override

--- a/src/test/java/io/axoniq/axonserver/connector/event/impl/BufferedAggregateEventStreamTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/event/impl/BufferedAggregateEventStreamTest.java
@@ -43,7 +43,7 @@ class BufferedAggregateEventStreamTest {
     @SuppressWarnings("unchecked")
     @BeforeEach
     void setUp() {
-        testSubject = new BufferedAggregateEventStream(10);
+        testSubject = new BufferedAggregateEventStream(10, 1);
         clientCallStreamObserver = mock(ClientCallStreamObserver.class);
         testSubject.beforeStart(clientCallStreamObserver);
     }

--- a/src/test/java/io/axoniq/axonserver/connector/impl/FlowControlledBufferTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/impl/FlowControlledBufferTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2021. AxonIQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.axoniq.axonserver.connector.impl;
+
+import io.axoniq.axonserver.grpc.FlowControl;
+import io.grpc.stub.ClientCallStreamObserver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@Timeout(5)
+class FlowControlledBufferTest {
+
+    private FlowControlledBuffer<String, String> testSubject;
+    private ClientCallStreamObserver<String> outboundStream;
+
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    void setUp() {
+        testSubject = new FlowControlledBuffer<String, String>("test", 1024, 8) {
+
+            @Override
+            protected String buildFlowControlMessage(FlowControl flowControl) {
+                return null;
+            }
+
+            @Override
+            protected String terminalMessage() {
+                return "TERMINAL";
+            }
+        };
+        outboundStream = mock(ClientCallStreamObserver.class);
+        testSubject.beforeStart(outboundStream);
+        verify(outboundStream).disableAutoRequestWithInitial(1024);
+    }
+
+    @Test
+    void testPermitsRefilledWhenMessagesConsumed() throws InterruptedException {
+        for (int i = 0; i < 16; i++) {
+            testSubject.onNext("Message" + i);
+        }
+        for (int i = 0; i < 7; i++) {
+            assertEquals("Message" + i, testSubject.tryTake(1, TimeUnit.SECONDS));
+        }
+        verify(outboundStream, never()).request(anyInt());
+        assertEquals("Message7", testSubject.tryTakeNow());
+        verify(outboundStream).request(8);
+        for (int i = 0; i < 8; i++) {
+            assertNotNull(testSubject.tryTakeNow());
+        }
+        verify(outboundStream, times(2)).request(8);
+
+        // the queue is empty. Attempting to consume messages should not increase the counter
+        for (int i = 0; i < 8; i++) {
+            assertNull(testSubject.tryTakeNow());
+        }
+        assertNull(testSubject.tryTake(1, TimeUnit.MILLISECONDS));
+        verify(outboundStream, times(2)).request(8);
+
+        testSubject.close();
+    }
+
+    @Test
+    void bufferReturnsAllMessagesWhenCompleted() {
+        for (int i = 0; i < 16; i++) {
+            testSubject.onNext("Message" + i);
+        }
+        testSubject.onCompleted();
+
+        for (int i = 0; i < 16; i++) {
+            assertFalse(testSubject.isClosed());
+            assertEquals("Message" + i, testSubject.tryTakeNow());
+        }
+        assertTrue(testSubject.isClosed());
+        assertNull(testSubject.tryTakeNow());
+    }
+
+    @Test
+    void bufferReturnsAllMessagesWhenClosedWithError() throws InterruptedException {
+        for (int i = 0; i < 16; i++) {
+            testSubject.onNext("Message" + i);
+        }
+        testSubject.onError(new RuntimeException("Mock Exception"));
+
+        for (int i = 0; i < 16; i++) {
+            assertFalse(testSubject.isClosed());
+            assertEquals("Message" + i, testSubject.tryTake());
+        }
+        assertTrue(testSubject.isClosed());
+        assertNotNull(testSubject.getErrorResult());
+        assertNull(testSubject.tryTakeNow());
+
+        StreamClosedException e = assertThrows(StreamClosedException.class, () -> testSubject.take());
+        assertNotNull(e.getCause());
+        assertEquals(RuntimeException.class, e.getCause().getClass());
+    }
+
+    @Test
+    void testPeekAndTryTakeReturnNullWhenNoMessagesAvailable() throws InterruptedException {
+        testSubject.onNext("Message");
+        assertEquals("Message", testSubject.peek());
+        assertEquals("Message", testSubject.take());
+
+        assertNull(testSubject.tryTakeNow());
+        assertNull(testSubject.tryTake(1, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    void testAllTakeMethodsReturnImmediatelyWhenStreamIsClosed() throws InterruptedException {
+        testSubject.onCompleted();
+        assertTrue(testSubject.isClosed());
+
+        assertThrows(StreamClosedException.class, () -> testSubject.take());
+
+        assertNull(testSubject.tryTakeNow());
+        assertNull(testSubject.tryTake());
+        assertTimeout(Duration.ofMillis(500), () ->
+                assertNull(testSubject.tryTake(5, TimeUnit.SECONDS)));
+        assertTrue(testSubject.isClosed());
+    }
+}

--- a/src/test/java/io/axoniq/axonserver/connector/impl/FlowControlledStreamTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/impl/FlowControlledStreamTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2021. AxonIQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.axoniq.axonserver.connector.impl;
+
+import io.axoniq.axonserver.grpc.FlowControl;
+import io.grpc.stub.ClientCallStreamObserver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+class FlowControlledStreamTest {
+
+    private ClientCallStreamObserver<String> outboundStream;
+
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    void setUp() {
+        outboundStream = mock(ClientCallStreamObserver.class);
+    }
+
+    @Test
+    void testParameterValuesAreValidated() {
+        assertThrows(IllegalArgumentException.class, () -> new TestFlowControlledStream("test", -1, 10));
+        assertThrows(IllegalArgumentException.class, () -> new TestFlowControlledStream("test", 9, 10));
+        assertThrows(IllegalArgumentException.class, () -> new TestFlowControlledStream(null, 1024, 10));
+        assertDoesNotThrow(() -> new TestFlowControlledStream("test", 10, 10));
+        assertDoesNotThrow(() -> new TestFlowControlledStream("test", 11, 10));
+    }
+
+    @Test
+    void permitsRefilledAfterConsumingMessages() {
+        TestFlowControlledStream testSubject = new TestFlowControlledStream("test", 1024, 8);
+        testSubject.beforeStart(outboundStream);
+
+        verify(outboundStream).disableAutoRequestWithInitial(1024);
+        for (int i = 0; i < 7; i++) {
+            testSubject.markConsumed();
+        }
+        verify(outboundStream, never()).request(anyInt());
+
+        testSubject.markConsumed();
+        verify(outboundStream).request(8);
+    }
+
+    @Test
+    void permitsRefilledAfterConsumingMessagesTogetherWithAppFlowControlMessage() {
+        TestFlowControlledStream testSubject = new TestFlowControlledStream("test", 1024, 8) {
+            @Override
+            protected String buildFlowControlMessage(FlowControl flowControl) {
+                return "UpdateFlowControlMessage";
+            }
+
+            @Override
+            protected String buildInitialFlowControlMessage(FlowControl flowControl) {
+                return "InitialFlowControlMessage";
+            }
+        };
+        testSubject.beforeStart(outboundStream);
+
+        verify(outboundStream).disableAutoRequestWithInitial(1024);
+
+        testSubject.enableFlowControl();
+        verify(outboundStream).onNext("InitialFlowControlMessage");
+
+        for (int i = 0; i < 7; i++) {
+            testSubject.markConsumed();
+        }
+
+        verify(outboundStream, never()).request(anyInt());
+
+        testSubject.markConsumed();
+        verify(outboundStream).request(8);
+        verify(outboundStream).onNext("UpdateFlowControlMessage");
+    }
+
+    private static class TestFlowControlledStream extends FlowControlledStream<String, String> {
+        public TestFlowControlledStream(String clientId, int permits, int refillBatch) {
+            super(clientId, permits, refillBatch);
+        }
+
+        @Override
+        public void onNext(String value) {
+
+        }
+
+        @Override
+        public void onError(Throwable t) {
+
+        }
+
+        @Override
+        public void onCompleted() {
+
+        }
+
+        @Override
+        protected String buildFlowControlMessage(FlowControl flowControl) {
+            return null;
+        }
+    }
+}

--- a/src/test/java/io/axoniq/axonserver/connector/query/QueryChannelIntegrationTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/query/QueryChannelIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020. AxonIQ
+ * Copyright (c) 2021. AxonIQ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -236,7 +236,7 @@ class QueryChannelIntegrationTest extends AbstractAxonServerIntegrationTest {
         });
         axonServerProxy.enable();
 
-        assertTrueWithin(1, TimeUnit.SECONDS, connection1::isReady);
+        assertTrueWithin(2, TimeUnit.SECONDS, connection1::isReady);
     }
 
     @RepeatedTest(20)


### PR DESCRIPTION
Added manual grpc-level flow control on all server-side streaming responses. This means that even for the requests where flow control isn't (or cannot) be managed from the application level messages, the flow of messages is adapted to the desired size of the client-side buffers.