### PR TITLE
Remove aggregate sequence validation

### DIFF
--- a/src/test/java/io/axoniq/axonserver/connector/event/impl/BufferedAggregateEventStreamTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/event/impl/BufferedAggregateEventStreamTest.java
@@ -2,14 +2,11 @@ package io.axoniq.axonserver.connector.event.impl;
 
 import io.axoniq.axonserver.connector.impl.StreamClosedException;
 import io.axoniq.axonserver.grpc.event.Event;
-import io.axoniq.axonserver.grpc.event.GetAggregateEventsRequest;
-import io.grpc.stub.ClientCallStreamObserver;
 import org.junit.jupiter.api.*;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 /**
  * Test class validationg the {@link BufferedAggregateEventStream}.
@@ -45,16 +42,4 @@ class BufferedAggregateEventStreamTest {
         assertThrows(StreamClosedException.class, () -> testSubject.hasNext());
     }
 
-    @Test
-    void testEventStreamErrorOnInvalidAggregateSequenceNumber() throws InterruptedException {
-        ClientCallStreamObserver clientCallStreamObserverMock = mock(ClientCallStreamObserver.class);
-        testSubject.beforeStart(clientCallStreamObserverMock);
-        testSubject.onNext(Event.getDefaultInstance());
-        testSubject.onNext(Event.getDefaultInstance());
-
-        assertTrue(testSubject.hasNext());
-        assertEquals(Event.getDefaultInstance(), testSubject.next());
-        verify(clientCallStreamObserverMock).onError(any(RuntimeException.class));
-        assertThrows(StreamClosedException.class, () -> testSubject.hasNext());
-    }
 }


### PR DESCRIPTION
Remove the aggregate sequence number validation in favour of the same validation in AxonServer. This fix also the invocation of the endpoint for retrieving multiple snapshots that, of course, has no sequential aggregate sequence numbers.