### PR TITLE
Improved connection recovery when using proxies

### DIFF
--- a/src/test/java/io/axoniq/axonserver/connector/command/CommandChannelIntegrationTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/command/CommandChannelIntegrationTest.java
@@ -194,8 +194,8 @@ class CommandChannelIntegrationTest extends AbstractAxonServerIntegrationTest {
 
         CompletableFuture<CommandResponse> actual1 = commandChannel.sendCommand(Command.newBuilder().setName("testCommand").build());
 
-        assertEquals("", actual1.get(100, TimeUnit.MILLISECONDS).getErrorMessage().getMessage());
-        assertEquals("", actual1.get(100, TimeUnit.MILLISECONDS).getErrorCode());
+        assertEquals("", actual1.get(1, TimeUnit.SECONDS).getErrorMessage().getMessage());
+        assertEquals("", actual1.get(1, TimeUnit.SECONDS).getErrorCode());
 
         registration.cancel().get(2, TimeUnit.SECONDS);
 

--- a/src/test/java/io/axoniq/axonserver/connector/impl/AxonServerManagedChannelIntegrationTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/impl/AxonServerManagedChannelIntegrationTest.java
@@ -48,6 +48,8 @@ import static io.axoniq.axonserver.connector.testutils.AssertUtils.assertWithin;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
@@ -111,6 +113,7 @@ class AxonServerManagedChannelIntegrationTest extends AbstractAxonServerIntegrat
     @Test
     void connectionReadyOnRequestConnection() {
         assertEquals(ConnectivityState.READY, testSubject.getState(true));
+        assertTrue(testSubject.isReady());
     }
 
     @Test
@@ -206,6 +209,16 @@ class AxonServerManagedChannelIntegrationTest extends AbstractAxonServerIntegrat
                                                        connectAttempts.add(address);
                                                        return localConnection.get();
                                                    });
+
+        // make sure we are properly connected, first
+        assertWithin(1, TimeUnit.SECONDS, () -> {
+            // make sure we run previously all scheduled (re)connect tasks
+            if (nextConnectTask != null) {
+                nextConnectTask.run();
+            }
+            assertSame(ConnectivityState.READY, testSubject.getState(true));
+        });
+
         // make sure we run previously all scheduled (re)connect tasks
         while (nextConnectTask != null) {
             nextConnectTask.run();

--- a/src/test/java/io/axoniq/axonserver/connector/query/QueryChannelIntegrationTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/query/QueryChannelIntegrationTest.java
@@ -235,7 +235,7 @@ class QueryChannelIntegrationTest extends AbstractAxonServerIntegrationTest {
         });
         axonServerProxy.enable();
 
-        assertWithin(1, TimeUnit.SECONDS, () -> assertTrue(connection1.isReady()));
+        assertWithin(2, TimeUnit.SECONDS, () -> assertTrue(connection1.isReady()));
     }
 
     @RepeatedTest(20)


### PR DESCRIPTION
This commit introduces a forced reconnect when the control channel
receives an UNAVAILABLE error while the connection is still active. This
likely indicates a proxy keeps the connection alive, while unable to
forward call to the backing service.
By forcing a reconned, the connector will reconnect using all available
servers, instead of waiting for the calls on the previous connection to
succeed.