### PR TITLE
Implemented ad-hoc query API for events

### DIFF
--- a/src/main/java/io/axoniq/axonserver/connector/event/EventChannel.java
+++ b/src/main/java/io/axoniq/axonserver/connector/event/EventChannel.java
@@ -54,7 +54,7 @@ public interface EventChannel {
      * cancel the schedule, or to reschedule the event to another time.
      *
      * @param scheduleTime The scheduleTime at which to publish the event
-     * @param event   The event to publish
+     * @param event        The event to publish
      * @return a token used to cancel the schedule
      */
     CompletableFuture<String> scheduleEvent(Instant scheduleTime, Event event);
@@ -329,21 +329,19 @@ public interface EventChannel {
      * whether the query should complete when the end of the Event Stream is reached, or if the query should continue
      * processing events as they are stored.
      *
-     * @param queryExpression A valid Event Stream Query Language expression
+     * @param queryExpression a valid Event Stream Query Language expression
      * @param liveStream      whether to continue processing live events
-     *
      * @return a ResultStream containing the query results
      */
     ResultStream<EventQueryResultEntry> queryEvents(String queryExpression, boolean liveStream);
 
     /**
      * Queries the Event Store for snapshot events using given {@code queryExpression}. The given {@code liveStream}
-     * indicates whether the query should complete when the end of the Snapshot Event Stream is reached, or if the
-     * query should continue processing snapshot events as they are stored.
+     * indicates whether the query should complete when the end of the Snapshot Event Stream is reached, or if the query
+     * should continue processing snapshot events as they are stored.
      *
-     * @param queryExpression A valid Event Stream Query Language expression
+     * @param queryExpression a valid Event Stream Query Language expression
      * @param liveStream      whether to continue processing live snapshot events
-     *
      * @return a ResultStream containing the query results
      */
     ResultStream<EventQueryResultEntry> querySnapshotEvents(String queryExpression, boolean liveStream);

--- a/src/main/java/io/axoniq/axonserver/connector/event/EventChannel.java
+++ b/src/main/java/io/axoniq/axonserver/connector/event/EventChannel.java
@@ -16,6 +16,7 @@
 
 package io.axoniq.axonserver.connector.event;
 
+import io.axoniq.axonserver.connector.ResultStream;
 import io.axoniq.axonserver.grpc.InstructionAck;
 import io.axoniq.axonserver.grpc.event.Confirmation;
 import io.axoniq.axonserver.grpc.event.Event;
@@ -322,4 +323,28 @@ public interface EventChannel {
      * given {@code instant}
      */
     CompletableFuture<Long> getTokenAt(long instant);
+
+    /**
+     * Queries the Event Store for events using given {@code queryExpression}. The given {@code liveStream} indicates
+     * whether the query should complete when the end of the Event Stream is reached, or if the query should continue
+     * processing events as they are stored.
+     *
+     * @param queryExpression A valid Event Stream Query Language expression
+     * @param liveStream      whether to continue processing live events
+     *
+     * @return a ResultStream containing the query results
+     */
+    ResultStream<EventQueryResultEntry> queryEvents(String queryExpression, boolean liveStream);
+
+    /**
+     * Queries the Event Store for snapshot events using given {@code queryExpression}. The given {@code liveStream}
+     * indicates whether the query should complete when the end of the Snapshot Event Stream is reached, or if the
+     * query should continue processing snapshot events as they are stored.
+     *
+     * @param queryExpression A valid Event Stream Query Language expression
+     * @param liveStream      whether to continue processing live snapshot events
+     *
+     * @return a ResultStream containing the query results
+     */
+    ResultStream<EventQueryResultEntry> querySnapshotEvents(String queryExpression, boolean liveStream);
 }

--- a/src/main/java/io/axoniq/axonserver/connector/event/EventQueryResultEntry.java
+++ b/src/main/java/io/axoniq/axonserver/connector/event/EventQueryResultEntry.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2020-2021. AxonIQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.axoniq.axonserver.connector.event;
+
+import java.util.List;
+
+/**
+ * Represents a single result from an Event Query.
+ * <p>
+ * Entries may represent an update to previous entries. The {@link #getIdentifiers()} result will be equal to the entry
+ * that is an update for. The number of entries will be the same for all results of the same query
+ * <p>
+ * If entries represent an ordered result, the {@link #getSortValues()} will return a list of values to sort on. The
+ * number of values will be equal in all entries for the same query.
+ */
+public interface EventQueryResultEntry {
+
+    /**
+     * The list of columns returned by the query. Will return the same value for all result entries of the same
+     * query.
+     *
+     * @return the names of the columns returned in this entry
+     */
+    List<String> columns();
+
+    /**
+     * Returns the value for the given {@code column}, casting it to the desired type.
+     * <p>
+     * The returned value can be a {@link String}, {@link Double}, {@link Long} or {@link Boolean}
+     *
+     * @param column The name of the column to return the data for
+     * @param <R>    the type to cast the result to
+     *
+     * @return the value associated with the given column
+     */
+    <R> R getValue(String column);
+
+    /**
+     * Returns the identifiers that uniquely identify this result entry. When multiple entries have equal identifier,
+     * the second result entry represents an updated version of the first.
+     *
+     * @return the identifiers for this entry
+     */
+    List<Object> getIdentifiers();
+
+    /**
+     * Returns the list of values to use to compare the order of this entry to other entries. Two
+     * entries with the same sort values cannot be considered equal, but rather don't have a defined order between them.
+     *
+     * @return the values to compare the order of entries
+     */
+    List<Object> getSortValues();
+
+    /**
+     * Returns the String value associated with the given column
+     *
+     * @param column The name of the column to return the value for
+     *
+     * @return the value associated with the column
+     * @throws ClassCastException when the value associated with the column is not a {@code String}
+     */
+    default String getValueAsString(String column) {
+        return getValue(column);
+    }
+
+    /**
+     * Returns the {@code long} value associated with the given column
+     *
+     * @param column The name of the column to return the value for
+     *
+     * @return the value associated with the column
+     * @throws ClassCastException when the value associated with the column is not a {@code long}
+     */
+    default long getValueAsLong(String column) {
+        return getValue(column);
+    }
+
+    /**
+     * Returns the {@code double} value associated with the given column
+     *
+     * @param column The name of the column to return the value for
+     *
+     * @return the value associated with the column
+     * @throws ClassCastException when the value associated with the column is not a {@code double}
+     */
+    default double getValueAsDouble(String column) {
+        return getValue(column);
+    }
+
+    /**
+     * Returns the {@code boolean} value associated with the given column
+     *
+     * @param column The name of the column to return the value for
+     *
+     * @return the value associated with the column
+     * @throws ClassCastException when the value associated with the column is not a {@code boolean}
+     */
+    default boolean getValueAsBoolean(String column) {
+        return getValue(column);
+    }
+
+}

--- a/src/main/java/io/axoniq/axonserver/connector/event/EventQueryResultEntry.java
+++ b/src/main/java/io/axoniq/axonserver/connector/event/EventQueryResultEntry.java
@@ -22,16 +22,18 @@ import java.util.List;
  * Represents a single result from an Event Query.
  * <p>
  * Entries may represent an update to previous entries. The {@link #getIdentifiers()} result will be equal to the entry
- * that is an update for. The number of entries will be the same for all results of the same query
+ * that it is an update for. The number of entries will be the same for all results of the same query.
  * <p>
  * If entries represent an ordered result, the {@link #getSortValues()} will return a list of values to sort on. The
  * number of values will be equal in all entries for the same query.
+ *
+ * @author Allard Buijze
+ * @since 4.5.1
  */
 public interface EventQueryResultEntry {
 
     /**
-     * The list of columns returned by the query. Will return the same value for all result entries of the same
-     * query.
+     * The list of columns returned by the query. Will return the same value for all result entries of the same query.
      *
      * @return the names of the columns returned in this entry
      */
@@ -42,9 +44,8 @@ public interface EventQueryResultEntry {
      * <p>
      * The returned value can be a {@link String}, {@link Double}, {@link Long} or {@link Boolean}
      *
-     * @param column The name of the column to return the data for
+     * @param column the name of the column to return the data for
      * @param <R>    the type to cast the result to
-     *
      * @return the value associated with the given column
      */
     <R> R getValue(String column);
@@ -58,18 +59,17 @@ public interface EventQueryResultEntry {
     List<Object> getIdentifiers();
 
     /**
-     * Returns the list of values to use to compare the order of this entry to other entries. Two
-     * entries with the same sort values cannot be considered equal, but rather don't have a defined order between them.
+     * Returns the list of values to use to compare the order of this entry to other entries. Two entries with the same
+     * sort values cannot be considered equal, but rather don't have a defined order between them.
      *
      * @return the values to compare the order of entries
      */
     List<Object> getSortValues();
 
     /**
-     * Returns the String value associated with the given column
+     * Returns the {@code String} value associated with the given column.
      *
-     * @param column The name of the column to return the value for
-     *
+     * @param column the name of the column to return the value for
      * @return the value associated with the column
      * @throws ClassCastException when the value associated with the column is not a {@code String}
      */
@@ -78,10 +78,9 @@ public interface EventQueryResultEntry {
     }
 
     /**
-     * Returns the {@code long} value associated with the given column
+     * Returns the {@code long} value associated with the given column.
      *
-     * @param column The name of the column to return the value for
-     *
+     * @param column the name of the column to return the value for
      * @return the value associated with the column
      * @throws ClassCastException when the value associated with the column is not a {@code long}
      */
@@ -90,10 +89,9 @@ public interface EventQueryResultEntry {
     }
 
     /**
-     * Returns the {@code double} value associated with the given column
+     * Returns the {@code double} value associated with the given column.
      *
-     * @param column The name of the column to return the value for
-     *
+     * @param column the name of the column to return the value for
      * @return the value associated with the column
      * @throws ClassCastException when the value associated with the column is not a {@code double}
      */
@@ -102,15 +100,13 @@ public interface EventQueryResultEntry {
     }
 
     /**
-     * Returns the {@code boolean} value associated with the given column
+     * Returns the {@code boolean} value associated with the given column.
      *
-     * @param column The name of the column to return the value for
-     *
+     * @param column the name of the column to return the value for
      * @return the value associated with the column
      * @throws ClassCastException when the value associated with the column is not a {@code boolean}
      */
     default boolean getValueAsBoolean(String column) {
         return getValue(column);
     }
-
 }

--- a/src/test/java/io/axoniq/axonserver/connector/testutils/MessageFactory.java
+++ b/src/test/java/io/axoniq/axonserver/connector/testutils/MessageFactory.java
@@ -31,4 +31,16 @@ public class MessageFactory {
                     .setTimestamp(System.currentTimeMillis())
                     .build();
     }
+
+    public static Event createDomainEvent(String payload, String aggregateIdentifier, long sequence) {
+        return Event.newBuilder().setPayload(SerializedObject.newBuilder()
+                                                             .setData(ByteString.copyFromUtf8(payload))
+                                                             .setType("string"))
+                    .setAggregateType("Aggregate")
+                    .setAggregateIdentifier(aggregateIdentifier)
+                    .setAggregateSequenceNumber(sequence)
+                    .setMessageIdentifier(UUID.randomUUID().toString())
+                    .setTimestamp(System.currentTimeMillis())
+                    .build();
+    }
 }

--- a/src/test/java/io/axoniq/axonserver/connector/testutils/MessageFactory.java
+++ b/src/test/java/io/axoniq/axonserver/connector/testutils/MessageFactory.java
@@ -22,7 +22,13 @@ import io.axoniq.axonserver.grpc.event.Event;
 
 import java.util.UUID;
 
+/**
+ * Utility class to construct messages, like an {@link Event}.
+ *
+ * @author Allard Buijze
+ */
 public class MessageFactory {
+
     public static Event createEvent(String payload) {
         return Event.newBuilder().setPayload(SerializedObject.newBuilder()
                                                              .setData(ByteString.copyFromUtf8(payload))


### PR DESCRIPTION
This PR introduces the ad-hoc query API for events and snapshots to the AxonServer connector.