### PR TITLE
Usability improvements

### DIFF
--- a/src/main/java/io/axoniq/axonserver/connector/AxonServerConnectionFactory.java
+++ b/src/main/java/io/axoniq/axonserver/connector/AxonServerConnectionFactory.java
@@ -85,9 +85,9 @@ public class AxonServerConnectionFactory {
     private final boolean suppressDownloadMessage;
     private final ReconnectConfiguration reconnectConfiguration;
     private final long processorInfoUpdateFrequency;
-    private volatile boolean shutdown;
     private final int commandPermits;
     private final int queryPermits;
+    private volatile boolean shutdown;
 
     /**
      * Instantiates an {@link AxonServerConnectionFactory} with the given {@code builder}.
@@ -505,29 +505,34 @@ public class AxonServerConnectionFactory {
         }
 
         /**
-         * Sets the number of messages that a Query Handler may receive before any of them have been processed.
+         * Sets the number of messages that a Query Handler may receive before any of them have been processed. Defaults
+         * to 5000.
+         * <p>
+         * Values lower than 16 will be replaced with 16.
          *
          * @param permits The number of initial permits
          *
          * @return this builder for further configuration
          */
         public Builder queryPermits(int permits) {
-            this.queryPermits = permits;
+            this.queryPermits = Math.max(16, permits);
             return this;
         }
 
         /**
          * Sets the number of messages that a Command Handler may receive before any of them have been processed.
+         * Defaults to 5000.
+         * <p>
+         * Values lower than 16 will be replaced with 16.
          *
          * @param permits The number of initial permits
          *
          * @return this builder for further configuration
          */
         public Builder commandPermits(int permits) {
-            this.commandPermits = permits;
+            this.commandPermits = Math.max(16, permits);
             return this;
         }
-
 
         /**
          * Validates the state of the builder, setting defaults where necessary.

--- a/src/main/java/io/axoniq/axonserver/connector/AxonServerConnectionFactory.java
+++ b/src/main/java/io/axoniq/axonserver/connector/AxonServerConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020. AxonIQ
+ * Copyright (c) 2020-2021. AxonIQ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,10 +83,11 @@ public class AxonServerConnectionFactory {
     private final ScheduledExecutorService executorService;
     private final Function<NettyChannelBuilder, ManagedChannelBuilder<?>> connectionConfig;
     private final boolean suppressDownloadMessage;
-
-    private volatile boolean shutdown;
     private final ReconnectConfiguration reconnectConfiguration;
     private final long processorInfoUpdateFrequency;
+    private volatile boolean shutdown;
+    private final int commandPermits;
+    private final int queryPermits;
 
     /**
      * Instantiates an {@link AxonServerConnectionFactory} with the given {@code builder}.
@@ -109,6 +110,8 @@ public class AxonServerConnectionFactory {
                 TimeUnit.MILLISECONDS
         );
         this.processorInfoUpdateFrequency = builder.processorInfoUpdateFrequency;
+        this.commandPermits = builder.commandPermits;
+        this.queryPermits = builder.queryPermits;
     }
 
     /**
@@ -118,6 +121,7 @@ public class AxonServerConnectionFactory {
      * information and should be the same only for instances of the same application or component.
      *
      * @param componentName The name of the component connecting to AxonServer
+     *
      * @return a builder instance for further configuration of the connector
      * @see #forClient(String, String)
      */
@@ -138,6 +142,7 @@ public class AxonServerConnectionFactory {
      *
      * @param componentName    The name of the component connecting to AxonServer
      * @param clientInstanceId The unique instance identifier for this instance of the component
+     *
      * @return a builder instance for further configuration of the connector
      * @see #forClient(String)
      */
@@ -149,6 +154,7 @@ public class AxonServerConnectionFactory {
      * Connects to the given {@code context} using the settings defined in this ConnectionFactory.
      *
      * @param context The name of the context to connect to
+     *
      * @return a Connection allowing interaction with the mentioned context
      */
     public AxonServerConnection connect(String context) {
@@ -181,6 +187,8 @@ public class AxonServerConnectionFactory {
                         this::createChannel
                 ),
                 processorInfoUpdateFrequency,
+                commandPermits,
+                queryPermits,
                 context
         );
     }
@@ -237,6 +245,8 @@ public class AxonServerConnectionFactory {
         private final String componentName;
         private final String clientInstanceId;
         private final Map<String, String> tags = new HashMap<>();
+        private int queryPermits = 5000;
+        private int commandPermits = 5000;
         private long processorInfoUpdateFrequency = 2000;
         private List<ServerAddress> routingServers;
         private long connectTimeout = 10000;
@@ -270,6 +280,7 @@ public class AxonServerConnectionFactory {
          * Defaults to "localhost:8024".
          *
          * @param serverAddresses The addresses to try to set up the initial connection with.
+         *
          * @return this builder for further configuration
          */
         public Builder routingServers(ServerAddress... serverAddresses) {
@@ -286,6 +297,7 @@ public class AxonServerConnectionFactory {
          *
          * @param interval The amount of time to wait in between connection attempts
          * @param timeUnit The unit in which the interval is expressed
+         *
          * @return this builder for further configuration
          */
         public Builder reconnectInterval(long interval, TimeUnit timeUnit) {
@@ -300,6 +312,7 @@ public class AxonServerConnectionFactory {
          *
          * @param timeout  The amount of time to wait for a connection to be established
          * @param timeUnit The unit in which the timout is expressed
+         *
          * @return this builder for further configuration
          */
         public Builder connectTimeout(long timeout, TimeUnit timeUnit) {
@@ -317,6 +330,7 @@ public class AxonServerConnectionFactory {
          * By default, no tags are defined.
          *
          * @param additionalClientTags additional tags that define this client component
+         *
          * @return this builder for further configuration
          */
         public Builder clientTags(Map<String, String> additionalClientTags) {
@@ -335,6 +349,7 @@ public class AxonServerConnectionFactory {
          *
          * @param key   the key of the Tag to configure
          * @param value the value of the Tag to configure
+         *
          * @return this builder for further configuration
          */
         public Builder clientTag(String key, String value) {
@@ -349,6 +364,7 @@ public class AxonServerConnectionFactory {
          * AxonServer.
          *
          * @param token The token to which the required authorizations have been assigned.
+         *
          * @return this builder for further configuration
          */
         public Builder token(String token) {
@@ -375,6 +391,7 @@ public class AxonServerConnectionFactory {
          * Defaults to not using TLS.
          *
          * @param sslContext The context defining TLS parameters
+         *
          * @return this builder for further configuration
          * @see SslContextBuilder#forClient()
          */
@@ -393,6 +410,7 @@ public class AxonServerConnectionFactory {
          * AxonServer instance.
          *
          * @param forceReconnectViaRoutingServers whether to force a reconnect to the Cluster via the RoutingServers.
+         *
          * @return this builder for further configuration
          */
         public Builder forceReconnectViaRoutingServers(boolean forceReconnectViaRoutingServers) {
@@ -408,6 +426,7 @@ public class AxonServerConnectionFactory {
          * Defaults to 2.
          *
          * @param poolSize The number of threads to assign to Connection related activities.
+         *
          * @return this builder for further configuration
          */
         public Builder threadPoolSize(int poolSize) {
@@ -430,6 +449,7 @@ public class AxonServerConnectionFactory {
          * @param interval time without read activity before sending a keepalive ping
          * @param timeout  the time waiting for read activity after sending a keepalive ping
          * @param timeUnit the unit in which the interval and timeout are expressed
+         *
          * @return this builder for further configuration
          */
         public Builder usingKeepAlive(long interval, long timeout, TimeUnit timeUnit, boolean keepAliveWithoutCalls) {
@@ -446,6 +466,7 @@ public class AxonServerConnectionFactory {
          * Default to 4 MiB.
          *
          * @param bytes The number of bytes to limit inbound message to
+         *
          * @return this builder for further configuration
          */
         public Builder maxInboundMessageSize(int bytes) {
@@ -461,6 +482,7 @@ public class AxonServerConnectionFactory {
          * feature.
          *
          * @param customization A function defining the customization to make on the ManagedChannelBuilder
+         *
          * @return this builder for further configuration
          */
         public Builder customize(UnaryOperator<ManagedChannelBuilder<?>> customization) {
@@ -474,12 +496,38 @@ public class AxonServerConnectionFactory {
          *
          * @param interval The interval in which to send status updates
          * @param unit     The unit of time in which the interval is expressed
+         *
          * @return this builder for further configuration
          */
         public Builder processorInfoUpdateFrequency(long interval, TimeUnit unit) {
             this.processorInfoUpdateFrequency = unit.toMillis(interval);
             return this;
         }
+
+        /**
+         * Sets the number of messages that a Query Handler may receive before any of them have been processed.
+         *
+         * @param permits The number of initial permits
+         *
+         * @return this builder for further configuration
+         */
+        public Builder queryPermits(int permits) {
+            this.queryPermits = permits;
+            return this;
+        }
+
+        /**
+         * Sets the number of messages that a Command Handler may receive before any of them have been processed.
+         *
+         * @param permits The number of initial permits
+         *
+         * @return this builder for further configuration
+         */
+        public Builder commandPermits(int permits) {
+            this.commandPermits = permits;
+            return this;
+        }
+
 
         /**
          * Validates the state of the builder, setting defaults where necessary.

--- a/src/main/java/io/axoniq/axonserver/connector/ReplyChannel.java
+++ b/src/main/java/io/axoniq/axonserver/connector/ReplyChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020. AxonIQ
+ * Copyright (c) 2020-2021. AxonIQ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/axoniq/axonserver/connector/impl/ContextConnection.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/ContextConnection.java
@@ -64,6 +64,8 @@ public class ContextConnection implements AxonServerConnection {
      * @param connection                   the {@link AxonServerManagedChannel} used to form the connections with
      *                                     AxonServer
      * @param processorInfoUpdateFrequency the update frequency in milliseconds of event processor information
+     * @param commandPermits               the number of permits for command streams
+     * @param queryPermits                 the number of permits for query streams
      * @param context                      the context this connection belongs to
      */
     public ContextConnection(ClientIdentification clientIdentification,

--- a/src/main/java/io/axoniq/axonserver/connector/query/impl/QueryChannelImpl.java
+++ b/src/main/java/io/axoniq/axonserver/connector/query/impl/QueryChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021. AxonIQ
+ * Copyright (c) 2020-2021. AxonIQ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -306,6 +306,9 @@ public class QueryChannelImpl extends AbstractAxonServerChannel<QueryProviderOut
 
     @Override
     public ResultStream<QueryResponse> query(QueryRequest query) {
+        if (query.getMessageIdentifier().isEmpty()) {
+            query = query.toBuilder().setMessageIdentifier(UUID.randomUUID().toString()).build();
+        }
         AbstractBufferedStream<QueryResponse, QueryRequest> results = new AbstractBufferedStream<QueryResponse, QueryRequest>(
                 clientIdentification.getClientId(), 32, 8
         ) {
@@ -334,10 +337,13 @@ public class QueryChannelImpl extends AbstractAxonServerChannel<QueryProviderOut
                                                      SerializedObject updateResponseType,
                                                      int bufferSize,
                                                      int fetchSize) {
-        if (!ObjectUtils.hasLength(query.getMessageIdentifier())) {
-            throw new IllegalArgumentException("QueryRequest must contain message identifier.");
+        QueryRequest finalQuery;
+        if (query.getMessageIdentifier().isEmpty()) {
+            finalQuery = query.toBuilder().setMessageIdentifier(UUID.randomUUID().toString()).build();
+        } else {
+            finalQuery = query;
         }
-        String subscriptionId = query.getMessageIdentifier();
+        String subscriptionId = finalQuery.getMessageIdentifier();
         CompletableFuture<QueryResponse> initialResultFuture = new CompletableFuture<>();
         SubscriptionQueryStream subscriptionStream = new SubscriptionQueryStream(
                 subscriptionId, initialResultFuture, QueryChannelImpl.this.clientIdentification.getClientId(),
@@ -346,7 +352,7 @@ public class QueryChannelImpl extends AbstractAxonServerChannel<QueryProviderOut
         StreamObserver<SubscriptionQueryRequest> upstream = queryServiceStub.subscription(subscriptionStream);
         subscriptionStream.enableFlowControl();
         SubscriptionQuery subscriptionQuery = SubscriptionQuery.newBuilder()
-                                                               .setQueryRequest(query)
+                                                               .setQueryRequest(finalQuery)
                                                                .setSubscriptionIdentifier(subscriptionId)
                                                                .setUpdateResponseType(updateResponseType)
                                                                .build();
@@ -360,7 +366,7 @@ public class QueryChannelImpl extends AbstractAxonServerChannel<QueryProviderOut
                 if (!initialResultFuture.isDone() && !initialResultRequested.getAndSet(true)) {
                     SubscriptionQuery.Builder initialResultRequest =
                             SubscriptionQuery.newBuilder()
-                                             .setQueryRequest(query)
+                                             .setQueryRequest(finalQuery)
                                              .setSubscriptionIdentifier(subscriptionId);
                     upstream.onNext(SubscriptionQueryRequest.newBuilder()
                                                             .setGetInitialResult(initialResultRequest)

--- a/src/test/java/io/axoniq/axonserver/connector/query/QueryChannelIntegrationTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/query/QueryChannelIntegrationTest.java
@@ -158,7 +158,7 @@ class QueryChannelIntegrationTest extends AbstractAxonServerIntegrationTest {
     }
 
     @RepeatedTest(10)
-    void testQueryChannelConsideredConnectedWhenNoHandlersSubscribed() throws IOException, TimeoutException, InterruptedException {
+    void testQueryChannelConsideredConnectedWhenNoHandlersSubscribed() throws IOException {
         QueryChannelImpl queryChannel = (QueryChannelImpl) connection1.queryChannel();
         // just to make sure that no attempt was made to connect, since there are no handlers
         assertTrue(queryChannel.isReady());
@@ -325,9 +325,7 @@ class QueryChannelIntegrationTest extends AbstractAxonServerIntegrationTest {
                                                                                                  SerializedObject.newBuilder().setType("update").build(),
                                                                                                  100, 10);
 
-        assertWithin(1, TimeUnit.SECONDS, () -> {
-            assertNotNull(updateHandlerRef.get());
-        });
+        assertWithin(1, TimeUnit.SECONDS, () -> assertNotNull(updateHandlerRef.get()));
 
         updateHandlerRef.get().sendUpdate(QueryUpdate.newBuilder().build());
         updateHandlerRef.get().complete();


### PR DESCRIPTION
Made number of permits for Command and Query Handlers configurable. Defaults to 5000.

Message identifier for Query and Subscription Query are optional. A random UUID is assigned when no identifier is provided.