### PR TITLE
Allow (re)connecting after a disconnect

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.15.2</version>
+            <version>1.16.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/io/axoniq/axonserver/connector/AxonServerConnectionFactory.java
+++ b/src/main/java/io/axoniq/axonserver/connector/AxonServerConnectionFactory.java
@@ -189,7 +189,8 @@ public class AxonServerConnectionFactory {
                 processorInfoUpdateFrequency,
                 commandPermits,
                 queryPermits,
-                context
+                context,
+                cnx -> connections.remove(context, cnx)
         );
     }
 

--- a/src/main/java/io/axoniq/axonserver/connector/impl/AxonServerManagedChannel.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/AxonServerManagedChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020. AxonIQ
+ * Copyright (c) 2020-2021. AxonIQ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -362,7 +362,7 @@ public class AxonServerManagedChannel extends ManagedChannel {
 
     private void verifyConnectionStateChange(ManagedChannel channel) {
         ConnectivityState currentState = channel.getState(false);
-        logger.debug("Connection state changed to {} scheduling connection check.}", currentState);
+        logger.debug("Connection state changed to {} scheduling connection check.", currentState);
         if (currentState != ConnectivityState.SHUTDOWN) {
             logger.debug("Registering new state change handler");
             channel.notifyWhenStateChanged(currentState, () -> verifyConnectionStateChange(channel));

--- a/src/main/java/io/axoniq/axonserver/connector/impl/ContextConnection.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/ContextConnection.java
@@ -69,6 +69,8 @@ public class ContextConnection implements AxonServerConnection {
      * @param commandPermits               the number of permits for command streams
      * @param queryPermits                 the number of permits for query streams
      * @param context                      the context this connection belongs to
+     * @param onShutdown                   a shutdown hook to invoke whenever this {@link ContextConnection}
+     *                                     disconnects
      */
     public ContextConnection(ClientIdentification clientIdentification,
                              ScheduledExecutorService executorService,
@@ -152,9 +154,14 @@ public class ContextConnection implements AxonServerConnection {
 
     @Override
     public CommandChannel commandChannel() {
-        CommandChannelImpl channel = this.commandChannel.updateAndGet(
-                createIfNull(() -> new CommandChannelImpl(clientIdentification, context, commandPermits, commandPermits / 4, executorService, connection))
-        );
+        CommandChannelImpl channel = this.commandChannel.updateAndGet(createIfNull(
+                () -> new CommandChannelImpl(clientIdentification,
+                                             context,
+                                             commandPermits,
+                                             commandPermits / 4,
+                                             executorService,
+                                             connection)
+        ));
         return ensureConnected(channel);
     }
 
@@ -168,9 +175,14 @@ public class ContextConnection implements AxonServerConnection {
 
     @Override
     public QueryChannel queryChannel() {
-        QueryChannelImpl channel = this.queryChannel.updateAndGet(
-                createIfNull(() -> new QueryChannelImpl(clientIdentification, context, queryPermits, queryPermits / 4, executorService, connection))
-        );
+        QueryChannelImpl channel = this.queryChannel.updateAndGet(createIfNull(
+                () -> new QueryChannelImpl(clientIdentification,
+                                           context,
+                                           queryPermits,
+                                           queryPermits / 4,
+                                           executorService,
+                                           connection)
+        ));
         return ensureConnected(channel);
     }
 

--- a/src/main/java/io/axoniq/axonserver/connector/query/impl/QueryChannelImpl.java
+++ b/src/main/java/io/axoniq/axonserver/connector/query/impl/QueryChannelImpl.java
@@ -290,7 +290,7 @@ public class QueryChannelImpl extends AbstractAxonServerChannel<QueryProviderOut
                     Set<QueryHandler> refs = queryHandlers.get(def.getQueryName());
                     if (refs != null && refs.remove(handler) && refs.isEmpty()) {
                         queryHandlers.remove(def.getQueryName());
-                        result = CompletableFuture.allOf(result, sendUnsubscribe(def));
+                        result = CompletableFuture.allOf(result, sendUnsubscribe(def, outboundQueryStream.get()));
                         logger.debug("Unregistered handlers for query '{}' in context '{}'", def, context);
                     }
                     supportedQueries.computeIfPresent(def, (qd, counter) -> counter.decrementAndGet() == 0 ? null : counter);
@@ -300,7 +300,10 @@ public class QueryChannelImpl extends AbstractAxonServerChannel<QueryProviderOut
         });
     }
 
-    private CompletableFuture<Void> sendUnsubscribe(QueryDefinition queryDefinition) {
+    private CompletableFuture<Void> sendUnsubscribe(QueryDefinition queryDefinition, StreamObserver<QueryProviderOutbound> outboundStream) {
+        if (outboundStream == null) {
+            return CompletableFuture.completedFuture(null);
+        }
         String instructionId = UUID.randomUUID().toString();
         QuerySubscription unsubscribeMessage =
                 QuerySubscription.newBuilder()
@@ -315,7 +318,7 @@ public class QueryChannelImpl extends AbstractAxonServerChannel<QueryProviderOut
                                                     .setUnsubscribe(unsubscribeMessage)
                                                     .build(),
                                QueryProviderOutbound::getInstructionId,
-                               outboundQueryStream.get());
+                               outboundStream);
     }
 
     @Override
@@ -402,9 +405,20 @@ public class QueryChannelImpl extends AbstractAxonServerChannel<QueryProviderOut
 
     @Override
     public synchronized void disconnect() {
-        CompletableFuture<Void> unsubscribed = prepareDisconnect();
-
         CallStreamObserver<QueryProviderOutbound> previousOutbound = outboundQueryStream.getAndSet(null);
+
+        CompletableFuture<Void> unsubscribed = previousOutbound == null
+                                               ? CompletableFuture.completedFuture(null)
+                                               : supportedQueries.keySet()
+                                                                 .stream()
+                                                                 .map(queryDefinition -> sendUnsubscribe(queryDefinition, previousOutbound))
+                                                                 .reduce(CompletableFuture::allOf)
+                                                                 .map(cf -> cf.exceptionally(e -> {
+                                                                     logger.warn("An error occurred while unregistering query handlers", e);
+                                                                     return null;
+                                                                 }))
+                                                                 .orElseGet(() -> CompletableFuture.completedFuture(null));
+        cancelAllSubscriptionQueries();
 
         unsubscribed.thenCompose(stream -> {
             if (!queriesInProgress.isEmpty()) {
@@ -424,14 +438,11 @@ public class QueryChannelImpl extends AbstractAxonServerChannel<QueryProviderOut
 
     @Override
     public CompletableFuture<Void> prepareDisconnect() {
+        CallStreamObserver<QueryProviderOutbound> outboundStream = outboundQueryStream.get();
         CompletableFuture<Void> future = supportedQueries.keySet()
                                                          .stream()
-                                                         .map(this::sendUnsubscribe)
+                                                         .map(queryDefinition -> sendUnsubscribe(queryDefinition, outboundStream))
                                                          .reduce(CompletableFuture::allOf)
-                                                         .map(cf -> cf.exceptionally(e -> {
-                                                             logger.warn("An error occurred while unregistering query handlers", e);
-                                                             return null;
-                                                         }))
                                                          .orElseGet(() -> CompletableFuture.completedFuture(null));
         cancelAllSubscriptionQueries();
         return future;

--- a/src/test/java/io/axoniq/axonserver/connector/impl/ControlChannelIntegrationTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/impl/ControlChannelIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020. AxonIQ
+ * Copyright (c) 2020-2021. AxonIQ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR introduces changes to the shutdown process that ensures connections can be reconnected to after a (manual) disconnect.

It also prevents some warnings from being logged as a result of calling `disconnect()` more than once.