### PR TITLE
Fix permit leak on cancelled query

### DIFF
--- a/src/main/java/io/axoniq/axonserver/connector/query/impl/QueryChannelImpl.java
+++ b/src/main/java/io/axoniq/axonserver/connector/query/impl/QueryChannelImpl.java
@@ -494,7 +494,10 @@ public class QueryChannelImpl extends AbstractAxonServerChannel<QueryProviderOut
 
     private void doHandleQuery(QueryRequest query, ReplyChannel<QueryResponse> responseChannel) {
         AtomicReference<io.axoniq.axonserver.connector.FlowControl> flowControlRef = new AtomicReference<>();
-        Runnable removeQuery = () -> queriesInProgress.remove(query.getMessageIdentifier());
+        Runnable removeQuery = () -> {
+            queriesInProgress.remove(query.getMessageIdentifier());
+            responseChannel.complete();
+        };
         QueryInProgress queryInProgress = new QueryInProgress(removeQuery, flowControlRef::get);
         if (queriesInProgress.putIfAbsent(query.getMessageIdentifier(), queryInProgress) != null) {
             return;


### PR DESCRIPTION
complete the response channel when a query is cancelled by the requester