### PR TITLE
Correctly handle exceptions during heartbeat check

### DIFF
--- a/src/main/java/io/axoniq/axonserver/connector/impl/HeartbeatMonitor.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/HeartbeatMonitor.java
@@ -101,11 +101,16 @@ public class HeartbeatMonitor {
     }
 
     private void checkAndReschedule(int task) {
-        if (task == taskId.get()) {
-            // heartbeats should not be considered valid when a change was made
-            checkBeat();
-            long delay = Math.min(interval.get(), 1000);
-            logger.debug("Heartbeat status checked. Scheduling next heartbeat verification in {}ms", delay);
+        long delay = Math.min(interval.get(), 1000);
+        try {
+            if (task == taskId.get()) {
+                // heartbeats should not be considered valid when a change was made
+                checkBeat();
+                logger.debug("Heartbeat status checked. Scheduling next heartbeat verification in {}ms", delay);
+            }
+        } catch (Exception e) {
+            logger.warn("Was unable to send heartbeat due to exception", e);
+        } finally {
             executor.schedule(() -> checkAndReschedule(task), delay, TimeUnit.MILLISECONDS);
         }
     }


### PR DESCRIPTION
Exceptions were not caught during sending the heartbeat. This can interrupt scheduling of the next check, effectively disabling heartbeats altogether. 

This PR adds a try/catch block with logging about the nature of the error, to improve resiliency