### PR TITLE
Throw TimeoutException when loading next even for aggregate takes too long

### DIFF
--- a/src/main/java/io/axoniq/axonserver/connector/event/impl/BufferedAggregateEventStream.java
+++ b/src/main/java/io/axoniq/axonserver/connector/event/impl/BufferedAggregateEventStream.java
@@ -19,12 +19,12 @@ package io.axoniq.axonserver.connector.event.impl;
 import io.axoniq.axonserver.connector.event.AggregateEventStream;
 import io.axoniq.axonserver.connector.impl.FlowControlledBuffer;
 import io.axoniq.axonserver.connector.impl.StreamClosedException;
+import io.axoniq.axonserver.connector.impl.StreamTimeoutException;
 import io.axoniq.axonserver.grpc.FlowControl;
 import io.axoniq.axonserver.grpc.event.Event;
 import io.axoniq.axonserver.grpc.event.GetAggregateEventsRequest;
 
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /**
  * Buffering implementation of the {@link AggregateEventStream} used for Event Sourced Aggregates.
@@ -34,8 +34,9 @@ public class BufferedAggregateEventStream
         implements AggregateEventStream {
 
     private static final Event TERMINAL_MESSAGE = Event.newBuilder().setAggregateSequenceNumber(-1729).build();
-    private static final int TIMEOUT_MILLIS = Integer.parseInt(System.getProperty("AGGREGATE_TAKE_EVENT_TIMEOUT_MILLIS",
-                                                                                  "10000"));
+    private static final int TAKE_TIMEOUT_MILLIS = Integer.parseInt(
+            System.getProperty("AGGREGATE_TAKE_EVENT_TIMEOUT_MILLIS", "10000")
+    );
 
     private Event peeked;
     private long lastSequenceNumber = -1;
@@ -78,16 +79,16 @@ public class BufferedAggregateEventStream
             return true;
         }
         try {
-            peeked = tryTake(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS, true);
+            peeked = tryTake(TAKE_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS, true);
         } catch (InterruptedException e) {
             cancel();
             Thread.currentThread().interrupt();
             return false;
-        } catch (TimeoutException e) {
-            throw new RuntimeException(
-                    String.format(
-                            "Was unable to load aggregate due to timeout while waiting for events. Last sequence number received: %d",
-                            lastSequenceNumber));
+        } catch (StreamTimeoutException e) {
+            throw new RuntimeException(String.format(
+                    "Was unable to load aggregate due to timeout while waiting for events. Last sequence number received: %d",
+                    lastSequenceNumber
+            ), e);
         }
         if (peeked == null) {
             Throwable errorResult = getErrorResult();

--- a/src/main/java/io/axoniq/axonserver/connector/event/impl/BufferedAggregateEventStream.java
+++ b/src/main/java/io/axoniq/axonserver/connector/event/impl/BufferedAggregateEventStream.java
@@ -22,10 +22,7 @@ import io.axoniq.axonserver.connector.impl.StreamClosedException;
 import io.axoniq.axonserver.grpc.FlowControl;
 import io.axoniq.axonserver.grpc.event.Event;
 import io.axoniq.axonserver.grpc.event.GetAggregateEventsRequest;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.lang.invoke.MethodHandles;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -36,7 +33,6 @@ public class BufferedAggregateEventStream
         extends FlowControlledBuffer<Event, GetAggregateEventsRequest>
         implements AggregateEventStream {
 
-    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private static final Event TERMINAL_MESSAGE = Event.newBuilder().setAggregateSequenceNumber(-1729).build();
     private static final int TIMEOUT_MILLIS = Integer.parseInt(System.getProperty("AGGREGATE_TAKE_EVENT_TIMEOUT_MILLIS",
                                                                                   "10000"));
@@ -88,11 +84,6 @@ public class BufferedAggregateEventStream
             Thread.currentThread().interrupt();
             return false;
         } catch (TimeoutException e) {
-            logger.debug(String.format(
-                    "Was unable to load aggregate due to timeout while waiting for events. Last sequence number received: %d. Permits: %d/%d",
-                    lastSequenceNumber,
-                    permitsConsumed(),
-                    permits()));
             throw new RuntimeException(
                     String.format(
                             "Was unable to load aggregate due to timeout while waiting for events. Last sequence number received: %d",

--- a/src/main/java/io/axoniq/axonserver/connector/impl/FlowControlledBuffer.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/FlowControlledBuffer.java
@@ -119,7 +119,7 @@ public abstract class FlowControlledBuffer<T, R> extends FlowControlledStream<T,
      * @param timeout  the duration to wait for an entry to become available in the buffer
      * @param timeUnit the {@link TimeUnit} used to specify the duration together with the {@code timeout}
      * @return an entry of type {@code T} from this buffer if present, otherwise {@code null}. Timeouts will result in
-     * null as well
+     * null as well.
      * @throws InterruptedException while waiting for an entry to be taken
      */
     protected T tryTake(long timeout, TimeUnit timeUnit) throws InterruptedException {

--- a/src/main/java/io/axoniq/axonserver/connector/impl/FlowControlledBuffer.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/FlowControlledBuffer.java
@@ -23,6 +23,7 @@ import io.grpc.stub.ClientCallStreamObserver;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -111,11 +112,36 @@ public abstract class FlowControlledBuffer<T, R> extends FlowControlledStream<T,
      *
      * @param timeout  the duration to wait for an entry to become available in the buffer
      * @param timeUnit the {@link TimeUnit} used to specify the duration together with the {@code timeout}
-     * @return an entry of type {@code T} from this buffer if present, otherwise {@code null}
+     * @return an entry of type {@code T} from this buffer if present, otherwise {@code null}. Timeouts will result in
+     * null as well
      * @throws InterruptedException while waiting for an entry to be taken
      */
     protected T tryTake(long timeout, TimeUnit timeUnit) throws InterruptedException {
-        T taken = validate(buffer.poll(timeout, timeUnit), true);
+        try {
+            return tryTake(timeout, timeUnit, false);
+        } catch (TimeoutException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Try to retrieve an entry of type {@code T} from the buffer, waiting for the duration of {@code timeout} in the
+     * given {@code timeUnit}. If none is present, {@code null} will be returned.
+     *
+     * @param timeout            the duration to wait for an entry to become available in the buffer
+     * @param timeUnit           the {@link TimeUnit} used to specify the duration together with the {@code timeout}
+     * @param exceptionOnTimeout Whether a {@code TimeoutException} should be thrown when the operation times out
+     * @return an entry of type {@code T} from this buffer if present, otherwise {@code null}
+     * @throws InterruptedException while waiting for an entry to be taken
+     * @throws TimeoutException     If there is no message available after waiting the allotted period
+     */
+    protected T tryTake(long timeout, TimeUnit timeUnit, boolean exceptionOnTimeout)
+            throws InterruptedException, TimeoutException {
+        T poll = buffer.poll(timeout, timeUnit);
+        if (poll == null && exceptionOnTimeout) {
+            throw new TimeoutException("Timeout while trying to peek next event from the stream");
+        }
+        T taken = validate(poll, true);
         if (taken != null) {
             markConsumed();
         }

--- a/src/main/java/io/axoniq/axonserver/connector/impl/FlowControlledBuffer.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/FlowControlledBuffer.java
@@ -46,6 +46,9 @@ public abstract class FlowControlledBuffer<T, R> extends FlowControlledStream<T,
      */
     public FlowControlledBuffer(String clientId, int bufferSize, int refillBatch) {
         super(clientId, bufferSize, refillBatch);
+        if (terminalMessage() == null) {
+            throw new IllegalStateException("Terminal message is not allowed to be null");
+        }
     }
 
     /**
@@ -57,6 +60,9 @@ public abstract class FlowControlledBuffer<T, R> extends FlowControlledStream<T,
 
     @Override
     public void onNext(T value) {
+        if (value == null) {
+            throw new NullPointerException("Next value of buffer is not allowed to be null");
+        }
         buffer.offer(value);
     }
 

--- a/src/main/java/io/axoniq/axonserver/connector/impl/FlowControlledStream.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/FlowControlledStream.java
@@ -109,6 +109,14 @@ public abstract class FlowControlledStream<IN, OUT> implements ClientResponseObs
         return clientId;
     }
 
+    protected int permits() {
+        return permits;
+    }
+
+    protected int permitsConsumed() {
+        return permitsConsumed.get();
+    }
+
     /**
      * Notifier when an entry has been consumed from this stream. Keeps track of the number of permits which has been
      * consumed and will automatically ask for new permits if the {@code permitsBatch} size has been reached.

--- a/src/main/java/io/axoniq/axonserver/connector/impl/FlowControlledStream.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/FlowControlledStream.java
@@ -109,14 +109,6 @@ public abstract class FlowControlledStream<IN, OUT> implements ClientResponseObs
         return clientId;
     }
 
-    protected int permits() {
-        return permits;
-    }
-
-    protected int permitsConsumed() {
-        return permitsConsumed.get();
-    }
-
     /**
      * Notifier when an entry has been consumed from this stream. Keeps track of the number of permits which has been
      * consumed and will automatically ask for new permits if the {@code permitsBatch} size has been reached.

--- a/src/main/java/io/axoniq/axonserver/connector/impl/StreamTimeoutException.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/StreamTimeoutException.java
@@ -1,0 +1,26 @@
+package io.axoniq.axonserver.connector.impl;
+
+/**
+ * A {@link RuntimeException} to throw if reading from a stream results in a timeout.
+ *
+ * @author Mitchell Herrijgers
+ * @since 4.5.6
+ */
+public class StreamTimeoutException extends RuntimeException {
+
+    /**
+     * Constructs a new instance of {@link StreamTimeoutException}.
+     */
+    public StreamTimeoutException() {
+    }
+
+    /**
+     * Constructs a new instance of {@link StreamTimeoutException} with a detailed description of the cause of the
+     * exception
+     *
+     * @param message the message describing the cause of the exception.
+     */
+    public StreamTimeoutException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/io/axoniq/axonserver/connector/event/impl/BufferedAggregateEventStreamTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/event/impl/BufferedAggregateEventStreamTest.java
@@ -90,7 +90,7 @@ class BufferedAggregateEventStreamTest {
      * final, so we have to work around the modifiers as well.
      */
     private void reduceTimeout() throws NoSuchFieldException, IllegalAccessException {
-        Field timeoutField = BufferedAggregateEventStream.class.getDeclaredField("TIMEOUT_MILLIS");
+        Field timeoutField = BufferedAggregateEventStream.class.getDeclaredField("TAKE_TIMEOUT_MILLIS");
         timeoutField.setAccessible(true);
 
         Field modifiersField = Field.class.getDeclaredField("modifiers");


### PR DESCRIPTION
In some very special cases it seems the aggregate keeps loading indefinitely. This PR puts a timeout, by default 10 seconds, on waiting for the next event in the stream.
This timeout can be customized using the `AGGREGATE_TAKE_EVENT_TIMEOUT_MILLIS` system property. 