### PR TITLE
Fix QueryChannelImpl healthcheck

### DIFF
--- a/src/main/java/io/axoniq/axonserver/connector/query/impl/QueryChannelImpl.java
+++ b/src/main/java/io/axoniq/axonserver/connector/query/impl/QueryChannelImpl.java
@@ -254,6 +254,7 @@ public class QueryChannelImpl extends AbstractAxonServerChannel<QueryProviderOut
                         .reduce(CompletableFuture::allOf)
                         .map(cf -> cf.exceptionally(e -> {
                             logger.warn("An error occurred while registering query handlers", e);
+                            subscriptionsCompleted.set(false);
                             return null;
                         }))
                         .orElse(CompletableFuture.completedFuture(null))
@@ -265,6 +266,7 @@ public class QueryChannelImpl extends AbstractAxonServerChannel<QueryProviderOut
 
     private void onConnectionError(Throwable error) {
         logger.info("Error on QueryChannel for context {}", context, error);
+        subscriptionsCompleted.set(false);
         scheduleReconnect(error);
     }
 
@@ -459,6 +461,7 @@ public class QueryChannelImpl extends AbstractAxonServerChannel<QueryProviderOut
                                     .reduce(CompletableFuture::allOf)
                                     .orElseGet(() -> CompletableFuture.completedFuture(null));
         }).thenAccept(previousStream -> doIfNotNull(previousOutbound, StreamObserver::onCompleted));
+        subscriptionsCompleted.set(false);
     }
 
     @Override


### PR DESCRIPTION
In normal situations, the current implementation of `QueryChannelImpl.isReady()` is sufficient. However, in some very rare cases the channel stays connected, while being unable to register query handlers. Despite the failing registering of the handlers the `isReady()` check wrongfully believes it's health, since the `subscriptionsCompleted` is never set to false in case of errors.

This PR fixes this problem by setting it to false in the case of errors during registering, and setting it to false during disconnection. The boolean is then determined again when connecting and succeeding.

Note: During a normal disconnect, the outbound stream would be set to null, so it normally works in the way it should. This is for the abnormal situation where the stream is not null, but it's not connected as well. 