### PR TITLE
Fix the subscriptionsCompleted boolean in query and command channels

### DIFF
--- a/src/main/java/io/axoniq/axonserver/connector/command/impl/CommandChannelImpl.java
+++ b/src/main/java/io/axoniq/axonserver/connector/command/impl/CommandChannelImpl.java
@@ -179,6 +179,7 @@ public class CommandChannelImpl extends AbstractAxonServerChannel<CommandProvide
                        .reduce(CompletableFuture::allOf)
                        .map(cf -> cf.exceptionally(e -> {
                            logger.warn("An error occurred while registering command handlers", e);
+                           subscriptionsCompleted.set(false);
                            return null;
                        }))
                        .orElse(CompletableFuture.completedFuture(null))
@@ -211,7 +212,9 @@ public class CommandChannelImpl extends AbstractAxonServerChannel<CommandProvide
                                                                 .map(commandName -> sendUnsubscribe(commandName, previousOutbound))
                                                                 .reduce(CompletableFuture::allOf)
                                                                 .map(cf -> cf.exceptionally(e -> {
-                                                                    logger.warn("An error occurred while unregistering command handlers", e);
+                                                                    logger.warn(
+                                                                            "An error occurred while unregistering command handlers",
+                                                                            e);
                                                                     return null;
                                                                 }))
                                                                 .orElseGet(() -> CompletableFuture.completedFuture(null));
@@ -224,9 +227,11 @@ public class CommandChannelImpl extends AbstractAxonServerChannel<CommandProvide
                     return CompletableFuture.allOf(inProgressCommands.stream()
                                                                      .reduce(CompletableFuture::allOf)
                                                                      .map(cf -> cf.exceptionally(e -> null))
-                                                                     .orElseGet(() -> CompletableFuture.completedFuture(null)));
+                                                                     .orElseGet(() -> CompletableFuture.completedFuture(
+                                                                             null)));
                 })
                 .thenRun(() -> doIfNotNull(previousOutbound, StreamObserver::onCompleted));
+        subscriptionsCompleted.set(false);
     }
 
     @Override

--- a/src/main/java/io/axoniq/axonserver/connector/query/impl/QueryChannelImpl.java
+++ b/src/main/java/io/axoniq/axonserver/connector/query/impl/QueryChannelImpl.java
@@ -225,6 +225,7 @@ public class QueryChannelImpl extends AbstractAxonServerChannel<QueryProviderOut
                         .reduce(CompletableFuture::allOf)
                         .map(cf -> cf.exceptionally(e -> {
                             logger.warn("An error occurred while registering query handlers", e);
+                            subscriptionsCompleted.set(false);
                             return null;
                         }))
                         .orElse(CompletableFuture.completedFuture(null))
@@ -236,6 +237,7 @@ public class QueryChannelImpl extends AbstractAxonServerChannel<QueryProviderOut
 
     private void onConnectionError(Throwable error) {
         logger.info("Error on QueryChannel for context {}", context, error);
+        subscriptionsCompleted.set(false);
         scheduleReconnect(error);
     }
 
@@ -428,6 +430,7 @@ public class QueryChannelImpl extends AbstractAxonServerChannel<QueryProviderOut
                                                             .reduce(CompletableFuture::allOf)
                                                             .orElseGet(() -> CompletableFuture.completedFuture(null)));
         }).thenAccept(previousStream -> doIfNotNull(previousOutbound, StreamObserver::onCompleted));
+        subscriptionsCompleted.set(false);
     }
 
     @Override

--- a/src/test/java/io/axoniq/axonserver/connector/AbstractAxonServerIntegrationTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/AbstractAxonServerIntegrationTest.java
@@ -24,8 +24,7 @@ import eu.rekawek.toxiproxy.ToxiproxyClient;
 import eu.rekawek.toxiproxy.model.Toxic;
 import io.axoniq.axonserver.connector.impl.ServerAddress;
 import io.axoniq.axonserver.connector.testutils.AxonServerUtils;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.*;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -54,7 +53,7 @@ public abstract class AbstractAxonServerIntegrationTest {
 
     @Container
     public static GenericContainer<?> axonServerContainer =
-            new GenericContainer<>(System.getProperty("AXON_SERVER_IMAGE", "axoniq/axonserver"))
+            new GenericContainer<>(System.getProperty("AXON_SERVER_IMAGE", "axoniq/axonserver:4.5.14-jdk-11-dev"))
                     .withExposedPorts(8024, 8124)
                     .withEnv("AXONIQ_AXONSERVER_NAME", "axonserver")
                     .withEnv("AXONIQ_AXONSERVER_HOSTNAME", "localhost")


### PR DESCRIPTION
This is the `4.5.x.` counterpart of #219.

In normal situations, the current implementation of `QueryChannelImpl.isReady()` is sufficient. However, in some very rare cases the channel stays connected, while being unable to register query handlers. Despite the failing registering of the handlers the `isReady()` check wrongfully believes it's health, since the `subscriptionsCompleted` is never set to false in case of errors.

This PR fixes this problem by setting it to false in the case of errors during registering, and setting it to false during disconnection. The boolean is then determined again when connecting and succeeding.

Note: During a normal disconnect, the outbound stream would be set to null, so it normally works in the way it should. This is for the abnormal situation where the stream is not null, but it's not connected as well. 