### PR TITLE
Add clientId and componentName to events request

### DIFF
--- a/src/main/java/io/axoniq/axonserver/connector/event/impl/BufferedEventStream.java
+++ b/src/main/java/io/axoniq/axonserver/connector/event/impl/BufferedEventStream.java
@@ -45,15 +45,20 @@ public class BufferedEventStream
     private final boolean forceReadFromLeader;
 
     /**
-     * Construct a {@link BufferedEventStream}, starting a position {@code trackingToken} with the given {@code
-     * bufferSize}.
+     * Construct a {@link BufferedEventStream}, starting a position {@code trackingToken} with the given
+     * {@code bufferSize}.
      *
-     * @param trackingToken       the position to start this {@link BufferedEventStream} at
-     * @param bufferSize          the buffer size of this event stream
-     * @param refillBatch         the number of Events to consume prior refilling the buffer
-     * @param forceReadFromLeader a {@code boolean} defining whether Events <b>must</b> be read from the leader
+     * @param clientId            The client identifier starting this stream.
+     * @param trackingToken       The position to start this {@link BufferedEventStream} at.
+     * @param bufferSize          The buffer size of this event stream.
+     * @param refillBatch         The number of Events to consume prior refilling the buffer.
+     * @param forceReadFromLeader A {@code boolean} defining whether Events <b>must</b> be read from the leader.
      */
-    public BufferedEventStream(ClientIdentification clientId, long trackingToken, int bufferSize, int refillBatch, boolean forceReadFromLeader) {
+    public BufferedEventStream(ClientIdentification clientId,
+                               long trackingToken,
+                               int bufferSize,
+                               int refillBatch,
+                               boolean forceReadFromLeader) {
         super(clientId.getClientId(), bufferSize, refillBatch);
         this.clientId = clientId;
         this.trackingToken = trackingToken;

--- a/src/main/java/io/axoniq/axonserver/connector/event/impl/EventChannelImpl.java
+++ b/src/main/java/io/axoniq/axonserver/connector/event/impl/EventChannelImpl.java
@@ -78,6 +78,7 @@ public class EventChannelImpl extends AbstractAxonServerChannel<Void> implements
     private final EventStoreGrpc.EventStoreStub eventStore;
     private final EventSchedulerGrpc.EventSchedulerStub eventScheduler;
     private final Set<BufferedEventStream> buffers = ConcurrentHashMap.newKeySet();
+    private final ClientIdentification clientId;
     // guarded by -this-
 
     /**
@@ -88,6 +89,7 @@ public class EventChannelImpl extends AbstractAxonServerChannel<Void> implements
      */
     public EventChannelImpl(ClientIdentification clientIdentification, ScheduledExecutorService executor, AxonServerManagedChannel channel) {
         super(clientIdentification, executor, channel);
+        clientId = clientIdentification;
         eventStore = EventStoreGrpc.newStub(channel);
         eventScheduler = EventSchedulerGrpc.newStub(channel);
     }
@@ -181,7 +183,7 @@ public class EventChannelImpl extends AbstractAxonServerChannel<Void> implements
 
     @Override
     public EventStream openStream(long token, int bufferSize, int refillBatch, boolean forceReadFromLeader) {
-        BufferedEventStream buffer = new BufferedEventStream(token,
+        BufferedEventStream buffer = new BufferedEventStream(clientId, token,
                                                              Math.max(64, bufferSize),
                                                              Math.max(16, Math.min(bufferSize, refillBatch)),
                                                              forceReadFromLeader);

--- a/src/main/java/io/axoniq/axonserver/connector/impl/AbstractIncomingInstructionStream.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/AbstractIncomingInstructionStream.java
@@ -52,6 +52,7 @@ public abstract class AbstractIncomingInstructionStream<IN, OUT> extends FlowCon
     private final Consumer<Throwable> disconnectHandler;
 
     private final Consumer<CallStreamObserver<OUT>> beforeStartHandler;
+    private final String clientId;
     private CallStreamObserver<OUT> instructionsForPlatform;
 
     /**
@@ -70,6 +71,7 @@ public abstract class AbstractIncomingInstructionStream<IN, OUT> extends FlowCon
                                                 Consumer<Throwable> disconnectHandler,
                                                 Consumer<CallStreamObserver<OUT>> beforeStartHandler) {
         super(clientId, permits, permitsBatch);
+        this.clientId = clientId;
         this.disconnectHandler = disconnectHandler;
         this.beforeStartHandler = beforeStartHandler;
     }
@@ -86,7 +88,7 @@ public abstract class AbstractIncomingInstructionStream<IN, OUT> extends FlowCon
             }
         } else {
             ForwardingReplyChannel<OUT> replyChannel = new ForwardingReplyChannel<>(getInstructionId(value),
-                                                                                    clientId(),
+                                                                                    clientId,
                                                                                     instructionsForPlatform,
                                                                                     this::buildAckMessage,
                                                                                     this::markConsumed);

--- a/src/main/java/io/axoniq/axonserver/connector/impl/FlowControlledStream.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/FlowControlledStream.java
@@ -101,15 +101,6 @@ public abstract class FlowControlledStream<IN, OUT> implements ClientResponseObs
     }
 
     /**
-     * Return the client identifier which has initiated this stream.
-     *
-     * @return the client identifier which has initiated this stream.
-     */
-    protected String clientId() {
-        return clientId;
-    }
-
-    /**
      * Notifier when an entry has been consumed from this stream. Keeps track of the number of permits which has been
      * consumed and will automatically ask for new permits if the {@code permitsBatch} size has been reached.
      */

--- a/src/main/java/io/axoniq/axonserver/connector/query/impl/SubscriptionQueryStream.java
+++ b/src/main/java/io/axoniq/axonserver/connector/query/impl/SubscriptionQueryStream.java
@@ -44,6 +44,7 @@ public class SubscriptionQueryStream extends FlowControlledStream<SubscriptionQu
     private final String subscriptionQueryId;
     private final CompletableFuture<QueryResponse> initialResultFuture;
     private final AbstractBufferedStream<QueryUpdate, SubscriptionQueryRequest> updateBuffer;
+    private final String clientId;
 
     /**
      * Instantiates a {@link SubscriptionQueryStream} to stream {@link SubscriptionQuery} results.
@@ -60,6 +61,7 @@ public class SubscriptionQueryStream extends FlowControlledStream<SubscriptionQu
                                    int bufferSize,
                                    int fetchSize) {
         super(clientId, bufferSize, fetchSize);
+        this.clientId = clientId;
         this.subscriptionQueryId = subscriptionQueryId;
         this.initialResultFuture = initialResultFuture;
         this.updateBuffer = new SubscriptionQueryUpdateBuffer(clientId, subscriptionQueryId, bufferSize, fetchSize);
@@ -135,7 +137,7 @@ public class SubscriptionQueryStream extends FlowControlledStream<SubscriptionQu
     public void onCompleted() {
         updateBuffer.onCompleted();
         if (!initialResultFuture.isDone()) {
-            initialResultFuture.completeExceptionally(new AxonServerException(ErrorCategory.QUERY_DISPATCH_ERROR, "Subscription query has already been completed", clientId()));
+            initialResultFuture.completeExceptionally(new AxonServerException(ErrorCategory.QUERY_DISPATCH_ERROR, "Subscription query has already been completed", clientId));
         }
     }
 

--- a/src/test/java/io/axoniq/axonserver/connector/command/CommandChannelIntegrationTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/command/CommandChannelIntegrationTest.java
@@ -26,10 +26,7 @@ import io.axoniq.axonserver.connector.command.impl.CommandChannelImpl;
 import io.axoniq.axonserver.connector.impl.ContextConnection;
 import io.axoniq.axonserver.grpc.command.Command;
 import io.axoniq.axonserver.grpc.command.CommandResponse;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.RepeatedTest;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,11 +43,7 @@ import java.util.concurrent.TimeoutException;
 import static io.axoniq.axonserver.connector.impl.ObjectUtils.doIfNotNull;
 import static io.axoniq.axonserver.connector.impl.ObjectUtils.silently;
 import static io.axoniq.axonserver.connector.testutils.AssertUtils.assertWithin;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class CommandChannelIntegrationTest extends AbstractAxonServerIntegrationTest {
 
@@ -149,8 +142,8 @@ class CommandChannelIntegrationTest extends AbstractAxonServerIntegrationTest {
         assertEquals("", commandResponse.getErrorMessage().getMessage());
     }
 
-    @RepeatedTest(10)
-    void testCommandChannelConsideredReadyWhenNoHandlersSubscribed() throws IOException, TimeoutException, InterruptedException {
+    @Test
+    void commandChannelConsideredReadyWhenNoHandlersSubscribed() throws IOException {
         CommandChannelImpl commandChannel = (CommandChannelImpl) connection1.commandChannel();
         // just to make sure that no attempt was made to connect, since there are no handlers
         assertTrue(commandChannel.isReady());
@@ -162,9 +155,10 @@ class CommandChannelIntegrationTest extends AbstractAxonServerIntegrationTest {
         assertTrue(commandChannel.isReady());
         assertFalse(connection1.isConnected());
 
-        Registration registration = commandChannel.registerCommandHandler(c -> CompletableFuture.completedFuture(null),
-                                                                          100, "TestCommand");
-        AxonServerException exception = assertThrows(AxonServerException.class, () -> registration.awaitAck(1, TimeUnit.SECONDS));
+        Registration registration =
+                commandChannel.registerCommandHandler(c -> CompletableFuture.completedFuture(null), 100, "TestCommand");
+        AxonServerException exception =
+                assertThrows(AxonServerException.class, () -> registration.awaitAck(1, TimeUnit.SECONDS));
         assertEquals(ErrorCategory.INSTRUCTION_ACK_ERROR, exception.getErrorCategory());
 
         // because of the attempt to set up a connection, it may need a few milliseconds to discover that's not possible


### PR DESCRIPTION
When opening an event stream, the client should provide the clientId and componentName to AxonServer, so that it can use these for reporting purposes.