### PR TITLE
Dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,10 +44,10 @@
         <axonserver.api.version>4.6.0</axonserver.api.version>
 
         <!-- For compatibility between grpc and tcnative, check https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty -->
-        <grpc.version>1.44.1</grpc.version>
-        <netty.tcnative.version>2.0.46.Final</netty.tcnative.version>
+        <grpc.version>1.49.0</grpc.version>
+        <netty.tcnative.version>2.0.53.Final</netty.tcnative.version>
 
-        <slf4j.version>2.0.0</slf4j.version>
+        <slf4j.version>1.7.36</slf4j.version>
         <log4j.version>2.18.0</log4j.version>
 
         <javax-annotation.version>1.3.2</javax-annotation.version>

--- a/src/main/java/io/axoniq/axonserver/connector/AxonServerConnectionFactory.java
+++ b/src/main/java/io/axoniq/axonserver/connector/AxonServerConnectionFactory.java
@@ -71,7 +71,7 @@ public class AxonServerConnectionFactory {
 
     private static final Logger logger = LoggerFactory.getLogger(AxonServerConnectionFactory.class);
 
-    private static final String CONNECTOR_VERSION = "4.4";
+    private static final String CONNECTOR_VERSION = "4.6";
 
     private final Map<String, String> tags = new HashMap<>();
     private final String componentName;


### PR DESCRIPTION
gRPC-netty updated to 1.49.0 and matching tc-native modules to address [CVE-2021-22569](https://nvd.nist.gov/vuln/detail/CVE-2021-22569) in Protobuf

Slf4J API was downgraded to 1.7.36 as there is no working log4j provider for the 2.0.0 version yet.