### PR TITLE
Upgrade Testcontainers dependency and replace OkHTTP3 for Apache HttpClient 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,12 +52,17 @@
 
         <javax-annotation.version>1.3.2</javax-annotation.version>
 
-        <junit.jupiter.version>5.8.2</junit.jupiter.version>
-        <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
-        <mockito.version>4.6.1</mockito.version>
         <reactive.streams.version>1.0.4</reactive.streams.version>
         <projectreactor.version>3.4.21</projectreactor.version>
+
+        <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
+        <junit.jupiter.version>5.8.2</junit.jupiter.version>
+        <mockito.version>4.6.1</mockito.version>
+        <testcontainers.version>1.17.4</testcontainers.version>
         <testng.version>7.5</testng.version>
+
+        <httpclient5.version>5.1.3</httpclient5.version>
+        <toxiproxy.version>2.1.7</toxiproxy.version>
     </properties>
 
     <dependencyManagement>
@@ -223,6 +228,8 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <!-- Testing -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
@@ -239,33 +246,42 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>eu.rekawek.toxiproxy</groupId>
-            <artifactId>toxiproxy-java</artifactId>
-            <version>2.1.7</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- Test containers -->
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.16.3</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>1.17.3</version>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>toxiproxy</artifactId>
-            <version>1.17.3</version>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Test networking -->
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>${httpclient5.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>eu.rekawek.toxiproxy</groupId>
+            <artifactId>toxiproxy-java</artifactId>
+            <version>${toxiproxy.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This pull request does two things, namely:

- Upgrading to the latest Testcontainers dependency
- Replacing use of OkHTTP3 for Apache HttpClient 5

The latter is a response to [#5113](https://github.com/testcontainers/testcontainers-java/pull/5113) from the testcontainers repository, which removed OkHTTP3 in favor of Apache HttpClient 5.
Moving through the issue landed me [here](https://github.com/docker-java/docker-java/blob/master/docs/transports.md#okhttp), which also points out that moving to Apache HttpClient 5 is a smart move.
Furthermore, changes had to be made regardless, as the aforementioned issue dropped the shaded dependency we were relying on.

Next to the above, this pull request resolves warnings and cleans the dependency set a little.

Doing so, this pull request replaces #240.