### PR TITLE
Ensure both TestNG and Jupiter tests are run

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
 
         <httpclient5.version>5.1.3</httpclient5.version>
         <toxiproxy.version>2.1.7</toxiproxy.version>
+        <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -137,6 +138,12 @@
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
                 <version>${testng.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.github.testng-team</groupId>
+                <artifactId>testng-junit5</artifactId>
+                <version>1.0.4</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>
@@ -401,7 +408,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>${maven.surefire.plugin.version}</version>
                 <configuration>
                     <includes>
                         <include>**/*Test.java</include>
@@ -410,6 +417,13 @@
                         <include>**/*Tests_*.java</include>
                     </includes>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit-platform</artifactId>
+                        <version>${maven.surefire.plugin.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>

--- a/src/test/java/io/axoniq/axonserver/connector/AbstractAxonServerIntegrationTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/AbstractAxonServerIntegrationTest.java
@@ -114,9 +114,10 @@ public abstract class AbstractAxonServerIntegrationTest {
         return proxy;
     }
 
-    protected JsonElement sendToAxonServer(Function<String, ClassicHttpRequest> method, String path)
-            throws IOException {
-        String uri = "https://" + axonServerContainer.getHost() + ":" + axonServerContainer.getMappedPort(8024) + path;
+    protected JsonElement sendToAxonServer(Function<String, ClassicHttpRequest> method,
+                                           String path) throws IOException {
+        //noinspection HttpUrlsUsage
+        String uri = "http://" + axonServerContainer.getHost() + ":" + axonServerContainer.getMappedPort(8024) + path;
         ClassicHttpRequest request = method.apply(uri);
 
         try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
@@ -151,7 +152,8 @@ public abstract class AbstractAxonServerIntegrationTest {
     }
 
     private HttpURLConnection getConnection(String path) throws IOException {
-        final URL url = new URL(String.format("https://%s:%d%s",
+        //noinspection HttpUrlsUsage
+        final URL url = new URL(String.format("http://%s:%d%s",
                                               axonServerContainer.getHost(),
                                               axonServerContainer.getMappedPort(8024),
                                               path));

--- a/src/test/java/io/axoniq/axonserver/connector/impl/ControlChannelIntegrationTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/impl/ControlChannelIntegrationTest.java
@@ -217,13 +217,13 @@ class ControlChannelIntegrationTest extends AbstractAxonServerIntegrationTest {
         String pausePath = "/v1/components/" + getClass().getSimpleName()
                 + "/processors/testProcessor/pause?tokenStoreIdentifier=TokenStoreId&context=default";
         assertWithin(1, TimeUnit.SECONDS, () -> sendToAxonServer(HttpPatch::new, pausePath));
-        assertWithin(4, TimeUnit.SECONDS, () -> assertTrue(instructionHandler.instructions.contains("pause")));
+        assertWithin(5, TimeUnit.SECONDS, () -> assertTrue(instructionHandler.instructions.contains("pause")));
         processorInfo.set(buildEventProcessorInfo(PAUSED_PROCESSOR));
 
         String startPath = "/v1/components/" + getClass().getSimpleName()
                 + "/processors/testProcessor/start?tokenStoreIdentifier=TokenStoreId&context=default";
         assertWithin(1, TimeUnit.SECONDS, () -> sendToAxonServer(HttpPatch::new, startPath));
-        assertWithin(4, TimeUnit.SECONDS, () -> assertTrue(instructionHandler.instructions.contains("start")));
+        assertWithin(5, TimeUnit.SECONDS, () -> assertTrue(instructionHandler.instructions.contains("start")));
     }
 
     @Test

--- a/src/test/java/io/axoniq/axonserver/connector/impl/ControlChannelIntegrationTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/impl/ControlChannelIntegrationTest.java
@@ -217,13 +217,13 @@ class ControlChannelIntegrationTest extends AbstractAxonServerIntegrationTest {
         String pausePath = "/v1/components/" + getClass().getSimpleName()
                 + "/processors/testProcessor/pause?tokenStoreIdentifier=TokenStoreId&context=default";
         assertWithin(1, TimeUnit.SECONDS, () -> sendToAxonServer(HttpPatch::new, pausePath));
-        assertWithin(2, TimeUnit.SECONDS, () -> assertTrue(instructionHandler.instructions.contains("pause")));
+        assertWithin(4, TimeUnit.SECONDS, () -> assertTrue(instructionHandler.instructions.contains("pause")));
         processorInfo.set(buildEventProcessorInfo(PAUSED_PROCESSOR));
 
         String startPath = "/v1/components/" + getClass().getSimpleName()
                 + "/processors/testProcessor/start?tokenStoreIdentifier=TokenStoreId&context=default";
         assertWithin(1, TimeUnit.SECONDS, () -> sendToAxonServer(HttpPatch::new, startPath));
-        assertWithin(2, TimeUnit.SECONDS, () -> assertTrue(instructionHandler.instructions.contains("start")));
+        assertWithin(4, TimeUnit.SECONDS, () -> assertTrue(instructionHandler.instructions.contains("start")));
     }
 
     @Test

--- a/src/test/java/io/axoniq/axonserver/connector/impl/ControlChannelIntegrationTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/impl/ControlChannelIntegrationTest.java
@@ -226,7 +226,7 @@ class ControlChannelIntegrationTest extends AbstractAxonServerIntegrationTest {
                 + "/processors/testProcessor/start?tokenStoreIdentifier=TokenStoreId&context=default";
         assertWithin(5, TimeUnit.SECONDS, () -> {
             sendToAxonServer(HttpPatch::new, startPath);
-            assertTrue(instructionHandler.instructions.contains("start"))
+            assertTrue(instructionHandler.instructions.contains("start"));
         });
     }
 

--- a/src/test/java/io/axoniq/axonserver/connector/impl/ControlChannelIntegrationTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/impl/ControlChannelIntegrationTest.java
@@ -216,14 +216,18 @@ class ControlChannelIntegrationTest extends AbstractAxonServerIntegrationTest {
 
         String pausePath = "/v1/components/" + getClass().getSimpleName()
                 + "/processors/testProcessor/pause?tokenStoreIdentifier=TokenStoreId&context=default";
-        assertWithin(1, TimeUnit.SECONDS, () -> sendToAxonServer(HttpPatch::new, pausePath));
-        assertWithin(5, TimeUnit.SECONDS, () -> assertTrue(instructionHandler.instructions.contains("pause")));
+        assertWithin(5, TimeUnit.SECONDS, () -> {
+            sendToAxonServer(HttpPatch::new, pausePath);
+            assertTrue(instructionHandler.instructions.contains("pause"));
+        });
         processorInfo.set(buildEventProcessorInfo(PAUSED_PROCESSOR));
 
         String startPath = "/v1/components/" + getClass().getSimpleName()
                 + "/processors/testProcessor/start?tokenStoreIdentifier=TokenStoreId&context=default";
-        assertWithin(1, TimeUnit.SECONDS, () -> sendToAxonServer(HttpPatch::new, startPath));
-        assertWithin(5, TimeUnit.SECONDS, () -> assertTrue(instructionHandler.instructions.contains("start")));
+        assertWithin(5, TimeUnit.SECONDS, () -> {
+            sendToAxonServer(HttpPatch::new, startPath);
+            assertTrue(instructionHandler.instructions.contains("start"))
+        });
     }
 
     @Test

--- a/src/test/java/io/axoniq/axonserver/connector/impl/ControlChannelIntegrationTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/impl/ControlChannelIntegrationTest.java
@@ -281,8 +281,8 @@ class ControlChannelIntegrationTest extends AbstractAxonServerIntegrationTest {
         String segmentToMove = "0";
         String segmentsPath = "/v1/components/" + getClass().getSimpleName() + "/processors/testProcessor/segments/" +
                 segmentToMove + "/move?tokenStoreIdentifier=TokenStoreId&context=default&target=foo";
-        assertWithin(1, TimeUnit.SECONDS, () -> sendToAxonServer(HttpPatch::new, segmentsPath));
-        assertWithin(1, TimeUnit.SECONDS,
+        assertWithin(2, TimeUnit.SECONDS, () -> sendToAxonServer(HttpPatch::new, segmentsPath));
+        assertWithin(2, TimeUnit.SECONDS,
                      () -> assertTrue(instructionHandler.instructions.contains("release" + segmentToMove)));
     }
 


### PR DESCRIPTION
With the introduction of TestNG, the `maven-surefire-plugin` defaulted to *only* running the TestNG tests.
This pull request resolves that, by adding the `testng-junit5` dependency to the project, and by enforcing the `surefire-junit-platform` on the `maven-surefire-plugin`.

In doing so, issues arose in the Integration Tests.
The simplest one was reverting the `https` operations to `http` operations, as that's required within the IT's
More complex where the start, pause, split, merge, and move tests.
These had old assumptions on how to invoke the endpoints and how to reply to those, requiring a number of adjustments.