### PR TITLE
Clean up `StreamObserver` on failed `openStream` attempt to solve No Handlers Found exception

### DIFF
--- a/src/main/java/io/axoniq/axonserver/connector/command/impl/CommandChannelImpl.java
+++ b/src/main/java/io/axoniq/axonserver/connector/command/impl/CommandChannelImpl.java
@@ -148,13 +148,14 @@ public class CommandChannelImpl extends AbstractAxonServerChannel<CommandProvide
     @Override
     public void connect() {
         if (!commandHandlers.isEmpty()) {
+            logger.debug("CommandChannel for context '{}' will attempt to connect.", context);
             doCreateCommandStream();
         }
     }
 
     private synchronized void doCreateCommandStream() {
         if (outboundCommandStream.get() != null) {
-            logger.debug("CommandChannel for context '{}' is already connected", context);
+            logger.debug("CommandChannel for context '{}' is already connected.", context);
             return;
         }
 
@@ -166,8 +167,15 @@ public class CommandChannelImpl extends AbstractAxonServerChannel<CommandProvide
                 this::registerOutboundStream
         );
 
-        //noinspection ResultOfMethodCallIgnored
-        commandServiceStub.openStream(responseObserver);
+        try {
+            //noinspection ResultOfMethodCallIgnored
+            commandServiceStub.openStream(responseObserver);
+        } catch (Exception e) {
+            logger.warn("Failed trying to open stream for CommandChannel in context [{}]. "
+                                + "Cleaning up for following attempt...", context, e);
+            outboundCommandStream.set(null);
+            throw e;
+        }
 
         StreamObserver<CommandProviderOutbound> newValue = responseObserver.getInstructionsForPlatform();
 
@@ -195,12 +203,14 @@ public class CommandChannelImpl extends AbstractAxonServerChannel<CommandProvide
 
     @Override
     public void reconnect() {
+        logger.debug("Reconnecting CommandChannel for context '{}'.", context);
         disconnect();
         scheduleImmediateReconnect();
     }
 
     @Override
     public void disconnect() {
+        logger.debug("Disconnecting CommandChannel for context '{}'.", context);
         StreamObserver<CommandProviderOutbound> previousOutbound = outboundCommandStream.getAndSet(null);
 
         CompletableFuture<Void> unsubscribed = previousOutbound == null
@@ -301,6 +311,7 @@ public class CommandChannelImpl extends AbstractAxonServerChannel<CommandProvide
 
     @Override
     public CompletableFuture<CommandResponse> sendCommand(Command command) {
+        logger.trace("Sending command over CommandChannel for context '{}'.", context);
         boolean hasRoutingKey = command.getProcessingInstructionsList()
                                        .stream()
                                        .anyMatch(pi -> pi.getKey() == ProcessingKey.ROUTING_KEY);
@@ -349,6 +360,7 @@ public class CommandChannelImpl extends AbstractAxonServerChannel<CommandProvide
 
     @Override
     public CompletableFuture<Void> prepareDisconnect() {
+        logger.debug("Preparing disconnect on CommandChannel for context '{}'.", context);
         return this.commandHandlers.keySet()
                                    .stream()
                                    .map(commandName -> sendUnsubscribe(commandName, outboundCommandStream.get()))

--- a/src/main/java/io/axoniq/axonserver/connector/impl/AxonServerManagedChannel.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/AxonServerManagedChannel.java
@@ -202,11 +202,11 @@ public class AxonServerManagedChannel extends ManagedChannel {
     public <REQ, RESP> ClientCall<REQ, RESP> newCall(MethodDescriptor<REQ, RESP> methodDescriptor,
                                                      CallOptions callOptions) {
         ManagedChannel current = activeChannel.get();
-        if (current == null || current.getState(false) != ConnectivityState.READY) {
+        if (current == null || current.isShutdown() || current.getState(false) != ConnectivityState.READY) {
             ensureConnected();
             current = activeChannel.get();
         }
-        if (current == null) {
+        if (current == null || current.isShutdown()) {
             return new FailingCall<>();
         }
         return current.newCall(methodDescriptor, callOptions);
@@ -227,7 +227,7 @@ public class AxonServerManagedChannel extends ManagedChannel {
             ensureConnected();
         }
         ManagedChannel current = activeChannel.get();
-        if (current == null) {
+        if (current == null || current.isShutdown()) {
             if (lastConnectException.get() == null) {
                 return ConnectivityState.IDLE;
             } else {


### PR DESCRIPTION
Whenever the `CommandChannelImpl` and `QueryChannelImpl` try to open a stream with their `CommandProviderOutbound` and `QueryProviderOutbound` respectively we should catch exceptions. 
Exceptions may occur when, for example, the connection to the Axon Server instance is down or faulty at that moment in time.

If we do not catch these exceptions, the channel implementations get stuck in a faulty state.
In this state, they've already created and their `StreamObserver` instance.
As the `StreamObserver` instance is used to deduce whether the connection is live, a following reconnect will be ignored. 
A consequence of this, is that the command and query handlers never get registered on a reconnect, resulting in the `NoHandlerForCommandException` and `NoHandlerForQueryException`

A user of the axonserver-connector-java module may reach this problematic state when all Axon Server connections are down while it dispatches a command or query.
This is particularly easy to replicate when using Axon Server Standard edition, as only a single connection is present.

To resolve the above, this pull request catches the exceptions on the `openStream` invocations towards gRPC.
If an exception is caught, the constructed `StreamObserver` is removed, thus resolving the faulty state.
Additionally to this, several debug and trace statements are introduced to ease future debugging.

Lastly, adding a test case to the Integration Test suite was difficult, as ToxiProxy only breaks the connection for a while instead of a harsh connection breakdown.
Due to this, it's not trivial to reach the above described state, and hence, no test cases were introduced.