### PR TITLE
Replace use of unregister for deregister

### DIFF
--- a/src/main/java/io/axoniq/axonserver/connector/command/CommandChannel.java
+++ b/src/main/java/io/axoniq/axonserver/connector/command/CommandChannel.java
@@ -36,7 +36,7 @@ public interface CommandChannel {
      * @param handler      the handler to handle incoming commands with
      * @param loadFactor   the relative load factor for this handler
      * @param commandNames the names of the commands to register the handler for
-     * @return a registration which allows the command handler to be unregistered
+     * @return a registration which allows the command handler to be deregistered
      */
     Registration registerCommandHandler(Function<Command, CompletableFuture<CommandResponse>> handler,
                                         int loadFactor,

--- a/src/main/java/io/axoniq/axonserver/connector/command/impl/CommandChannelImpl.java
+++ b/src/main/java/io/axoniq/axonserver/connector/command/impl/CommandChannelImpl.java
@@ -210,7 +210,7 @@ public class CommandChannelImpl extends AbstractAxonServerChannel<CommandProvide
                                                                 .map(commandName -> sendUnsubscribe(commandName, previousOutbound))
                                                                 .reduce(CompletableFuture::allOf)
                                                                 .map(cf -> cf.exceptionally(e -> {
-                                                                    logger.warn("An error occurred while unregistering command handlers", e);
+                                                                    logger.warn("An error occurred while deregistering command handlers", e);
                                                                     return null;
                                                                 }))
                                                                 .orElseGet(() -> CompletableFuture.completedFuture(null));
@@ -273,7 +273,7 @@ public class CommandChannelImpl extends AbstractAxonServerChannel<CommandProvide
         CompletableFuture<Void> future = CompletableFuture.completedFuture(null);
         for (String commandName : commandNames) {
             if (commandHandlers.get(commandName) == handler) {
-                logger.info("Unregistered handler for command '{}' in context '{}'", commandName, context);
+                logger.info("Deregistered handler for command '{}' in context '{}'", commandName, context);
                 CompletableFuture<Void> result = sendUnsubscribe(commandName, outboundCommandStream.get())
                         .thenRun(() -> commandHandlers.remove(commandName, handler));
                 future = CompletableFuture.allOf(future, result);

--- a/src/main/java/io/axoniq/axonserver/connector/control/ControlChannel.java
+++ b/src/main/java/io/axoniq/axonserver/connector/control/ControlChannel.java
@@ -43,7 +43,7 @@ public interface ControlChannel {
      *
      * @param type    the type of instructions to handle
      * @param handler the handler to invoke for incoming instructions
-     * @return a handle to unregister this instruction handler
+     * @return a handle to deregister this instruction handler
      */
     Registration registerInstructionHandler(PlatformOutboundInstruction.RequestCase type,
                                             InstructionHandler<PlatformOutboundInstruction, PlatformInboundInstruction> handler);

--- a/src/main/java/io/axoniq/axonserver/connector/impl/AbstractIncomingInstructionStream.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/AbstractIncomingInstructionStream.java
@@ -179,12 +179,12 @@ public abstract class AbstractIncomingInstructionStream<IN, OUT> extends FlowCon
     }
 
     /**
-     * Unregisters this stream's outbound stream, granted that it matches the given {@code expected} {@link
+     * Deregisters this stream's outbound stream, granted that it matches the given {@code expected} {@link
      * StreamObserver}. Will return {@code true} if they matched and {@code false} otherwise.
      *
-     * @param expected the expected {@link StreamObserver} to be unregistered
+     * @param expected the expected {@link StreamObserver} to be deregistered
      *
-     * @return {@code true} if the outbound stream was successfully unregistered, {@code false} otherwise
+     * @return {@code true} if the outbound stream was successfully deregistered, {@code false} otherwise
      */
     protected abstract boolean unregisterOutboundStream(CallStreamObserver<OUT> expected);
 }

--- a/src/main/java/io/axoniq/axonserver/connector/query/QueryChannel.java
+++ b/src/main/java/io/axoniq/axonserver/connector/query/QueryChannel.java
@@ -35,7 +35,7 @@ public interface QueryChannel {
      *
      * @param handler    the handler to handle incoming queries with
      * @param queryTypes the {@link QueryDefinition}s to register the handler for
-     * @return a registration which allows the query handler to be unregistered
+     * @return a registration which allows the query handler to be deregistered
      */
     Registration registerQueryHandler(QueryHandler handler, QueryDefinition... queryTypes);
 

--- a/src/main/java/io/axoniq/axonserver/connector/query/impl/QueryChannelImpl.java
+++ b/src/main/java/io/axoniq/axonserver/connector/query/impl/QueryChannelImpl.java
@@ -321,7 +321,7 @@ public class QueryChannelImpl extends AbstractAxonServerChannel<QueryProviderOut
                     if (refs != null && refs.remove(handler) && refs.isEmpty()) {
                         queryHandlers.remove(def.getQueryName());
                         result = CompletableFuture.allOf(result, sendUnsubscribe(def, outboundQueryStream.get()));
-                        logger.debug("Unregistered handlers for query '{}' in context '{}'", def, context);
+                        logger.debug("Deregistered handlers for query '{}' in context '{}'", def, context);
                     }
                     supportedQueries.computeIfPresent(def, (qd, counter) -> counter.decrementAndGet() == 0 ? null : counter);
                 }
@@ -444,7 +444,7 @@ public class QueryChannelImpl extends AbstractAxonServerChannel<QueryProviderOut
                                                                  .map(queryDefinition -> sendUnsubscribe(queryDefinition, previousOutbound))
                                                                  .reduce(CompletableFuture::allOf)
                                                                  .map(cf -> cf.exceptionally(e -> {
-                                                                     logger.warn("An error occurred while unregistering query handlers", e);
+                                                                     logger.warn("An error occurred while deregistering query handlers", e);
                                                                      return null;
                                                                  }))
                                                                  .orElseGet(() -> CompletableFuture.completedFuture(null));

--- a/src/test/java/io/axoniq/axonserver/connector/query/QueryChannelIntegrationTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/query/QueryChannelIntegrationTest.java
@@ -327,7 +327,7 @@ class QueryChannelIntegrationTest extends AbstractAxonServerIntegrationTest {
         assertWithin(1, TimeUnit.SECONDS, () -> {
             assertNull(subscriptionQuery.updates().nextIfAvailable());
             assertTrue(subscriptionQuery.updates().isClosed(), "Client side update stream should have been closed");
-            assertNull(updateHandlerRef.get(), "Expected updateHandler to have been unregistered");
+            assertNull(updateHandlerRef.get(), "Expected updateHandler to have been deregistered");
         });
     }
 
@@ -373,8 +373,8 @@ class QueryChannelIntegrationTest extends AbstractAxonServerIntegrationTest {
         assertNull(updates.nextIfAvailable());
 
         assertWithin(1, TimeUnit.SECONDS, () -> {
-            assertTrue(updates.isClosed(), "Expected client side to be unregistered");
-            assertNull(updateHandlerRef.get(), "Expected UpdateHandler to be unregistered");
+            assertTrue(updates.isClosed(), "Expected client side to be deregistered");
+            assertNull(updateHandlerRef.get(), "Expected UpdateHandler to be deregistered");
         });
     }
 


### PR DESCRIPTION
As mentioned in Axon Framework issue [2456](https://github.com/AxonFramework/AxonFramework/issues/2456), the use of unregister is incorrect use of the English language. 
Unregister may only be used if something was never registered to begin with. 
All occurrences are, however, describing the removal of an existing registration, which should be called deregister instead.

This pull request resolve this predicament for the `axonserver-connector-java` project.