### PR TITLE
Fix Download Message Suppression Logic

### DIFF
--- a/src/main/java/io/axoniq/axonserver/connector/AxonServerConnectionFactory.java
+++ b/src/main/java/io/axoniq/axonserver/connector/AxonServerConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021. AxonIQ
+ * Copyright (c) 2020-2023. AxonIQ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -285,7 +285,6 @@ public class AxonServerConnectionFactory {
          * @return this builder for further configuration
          */
         public Builder routingServers(ServerAddress... serverAddresses) {
-            suppressDownloadMessage = true;
             this.routingServers = new ArrayList<>(Arrays.asList(serverAddresses));
             return this;
         }
@@ -559,7 +558,19 @@ public class AxonServerConnectionFactory {
          */
         public AxonServerConnectionFactory build() {
             validate();
+            suppressDownloadMessage = customizedServerAddressProvided(routingServers)
+                    || Boolean.getBoolean("axon.axonserver.suppressDownloadMessage");
             return new AxonServerConnectionFactory(this);
+        }
+
+        private static boolean customizedServerAddressProvided(List<ServerAddress> serverAddresses) {
+            if (serverAddresses.size() > 1) {
+                return true;
+            }
+            if (serverAddresses.isEmpty()) {
+                return false;
+            }
+            return !ServerAddress.DEFAULT.equals(serverAddresses.get(0));
         }
     }
 

--- a/src/main/java/io/axoniq/axonserver/connector/impl/ServerAddress.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/ServerAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020. AxonIQ
+ * Copyright (c) 2023. AxonIQ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,12 @@ import java.util.Objects;
  * Definition of an AxonServer address, defining the {@link #getGrpcPort()} and {@link #getHostName()}.
  */
 public class ServerAddress {
+
+    /**
+     * A default {@link ServerAddress}, using {@link #getHostName() host} {@code "localhost"} and
+     * {@link #getGrpcPort() gRPC port} {@code 8124}.
+     */
+    public static final ServerAddress DEFAULT = new ServerAddress();
 
     private final int grpcPort;
     private final String host;

--- a/src/test/java/io/axoniq/axonserver/connector/AxonServerConnectionFactoryTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/AxonServerConnectionFactoryTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2023. AxonIQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.axoniq.axonserver.connector;
+
+import io.axoniq.axonserver.connector.impl.ServerAddress;
+import org.junit.jupiter.api.*;
+import org.testng.reporters.Files;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class validating the {@link AxonServerConnectionFactory}.
+ *
+ * @author Steven van Beelen
+ */
+class AxonServerConnectionFactoryTest {
+
+    private static final String TEST_COMPONENT_NAME = "some-component-name";
+    private static final String TEST_CONTEXT = "some-context";
+
+    private final ByteArrayOutputStream systemOut = new ByteArrayOutputStream();
+    private final PrintStream originalSystemOut = System.out;
+
+    private String downloadMessage;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        System.setOut(new PrintStream(systemOut));
+
+        try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream("axonserver_download.txt")) {
+            // noinspection DataFlowIssue
+            downloadMessage = Files.readFile(inputStream);
+        }
+    }
+
+    @AfterEach
+    void tearDown() {
+        System.setOut(originalSystemOut);
+        System.clearProperty("axon.axonserver.suppressDownloadMessage");
+    }
+
+    @Test
+    void downloadMessageIsNotSuppressedForDefaultServerAddress() {
+        assertFalse(downloadMessage.isEmpty());
+
+        AxonServerConnectionFactory testSubject = AxonServerConnectionFactory.forClient(TEST_COMPONENT_NAME)
+                                                                             .routingServers(ServerAddress.DEFAULT)
+                                                                             .build();
+
+        testSubject.connect(TEST_CONTEXT);
+        assertTrue(systemOut.toString().contains(downloadMessage));
+    }
+
+    @Test
+    void downloadMessageIsSuppressedForNoneDefaultServerAddress() {
+        assertFalse(downloadMessage.isEmpty());
+
+        ServerAddress customAddress = new ServerAddress("my-host", 4218);
+        AxonServerConnectionFactory testSubject = AxonServerConnectionFactory.forClient(TEST_COMPONENT_NAME)
+                                                                             .routingServers(customAddress)
+                                                                             .build();
+
+        testSubject.connect(TEST_CONTEXT);
+
+        assertFalse(systemOut.toString().contains(downloadMessage));
+    }
+
+    @Test
+    void downloadMessageIsSuppressedWhenSuppressionPropertyIsSet() {
+        assertFalse(downloadMessage.isEmpty());
+
+        System.setProperty("axon.axonserver.suppressDownloadMessage", "true");
+        AxonServerConnectionFactory testSubject = AxonServerConnectionFactory.forClient(TEST_COMPONENT_NAME)
+                                                                             .routingServers(ServerAddress.DEFAULT)
+                                                                             .build();
+
+        testSubject.connect(TEST_CONTEXT);
+
+        assertFalse(systemOut.toString().contains(downloadMessage));
+    }
+}


### PR DESCRIPTION
This pull request resolves the logic around the `suppressDownloadMessage` toggle.
This toggle is set to `true` on *any* invocation or `AxonServerConnectionFactory.Builder#routingServers`.
However, this invocation is *always* invoked, hence the download message never shows.

To resolve this, this pull request checks whether:
1. A single `ServerAddress` is provided, and
2. If so, check whether it is a default `ServerAddress` of host `localhost` and port `8124`.

Next to the default address validation, reintroduce the `axon.axonserver.suppressDownloadMessage` property check.
When set, retrieve the value set under this system property.

Lastly, a test is introduced to validate that the existing `axonserver_download.txt` is shared, yes/no.