### PR TITLE
Introduced dependency on grpc-netty-shaded

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,8 +44,7 @@
         <axonserver.api.version>2023.0.1</axonserver.api.version>
 
         <!-- For compatibility between grpc and tcnative, check https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty -->
-        <grpc.version>1.50.2</grpc.version>
-        <netty.tcnative.version>2.0.54.Final</netty.tcnative.version>
+        <grpc.version>1.59.0</grpc.version>
 
         <slf4j.version>1.7.36</slf4j.version>
         <log4j.version>2.22.0</log4j.version>
@@ -191,13 +190,8 @@
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
-            <artifactId>grpc-netty</artifactId>
+            <artifactId>grpc-netty-shaded</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-tcnative-boringssl-static</artifactId>
-        </dependency>
-
         <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2020-2021. AxonIQ
+  ~ Copyright (c) 2020-2023. AxonIQ
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -43,8 +43,7 @@
     <properties>
         <axonserver.api.version>2023.0.1</axonserver.api.version>
 
-        <!-- For compatibility between grpc and tcnative, check https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty -->
-        <grpc.version>1.59.0</grpc.version>
+        <grpc.version>1.59.1</grpc.version>
 
         <slf4j.version>1.7.36</slf4j.version>
         <log4j.version>2.22.0</log4j.version>
@@ -94,11 +93,6 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-log4j12</artifactId>
                 <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-tcnative-boringssl-static</artifactId>
-                <version>${netty.tcnative.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/io/axoniq/axonserver/connector/AxonServerConnectionFactory.java
+++ b/src/main/java/io/axoniq/axonserver/connector/AxonServerConnectionFactory.java
@@ -36,9 +36,9 @@ import io.grpc.ManagedChannelBuilder;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
-import io.grpc.netty.NettyChannelBuilder;
-import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
+import io.grpc.netty.shaded.io.netty.handler.ssl.SslContextBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/io/axoniq/axonserver/connector/command/impl/CommandChannelImpl.java
+++ b/src/main/java/io/axoniq/axonserver/connector/command/impl/CommandChannelImpl.java
@@ -40,9 +40,9 @@ import io.axoniq.axonserver.grpc.command.CommandResponse;
 import io.axoniq.axonserver.grpc.command.CommandServiceGrpc;
 import io.axoniq.axonserver.grpc.command.CommandSubscription;
 import io.axoniq.axonserver.grpc.control.ClientIdentification;
+import io.grpc.netty.shaded.io.netty.util.internal.OutOfDirectMemoryError;
 import io.grpc.stub.CallStreamObserver;
 import io.grpc.stub.StreamObserver;
-import io.netty.util.internal.OutOfDirectMemoryError;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/test/java/io/axoniq/axonserver/connector/AbstractAxonServerIntegrationTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/AbstractAxonServerIntegrationTest.java
@@ -56,7 +56,7 @@ public abstract class AbstractAxonServerIntegrationTest {
     @SuppressWarnings("resource")
     @Container
     public static GenericContainer<?> axonServerContainer =
-            new GenericContainer<>(System.getProperty("AXON_SERVER_IMAGE", "axoniq/axonserver-enterprise:latest-dev"))
+            new GenericContainer<>(System.getProperty("AXON_SERVER_IMAGE", "axoniq/axonserver"))
                     .withExposedPorts(8024, 8124)
                     .withEnv("AXONIQ_AXONSERVER_PREVIEW_EVENT_TRANSFORMATION", "true")
                     .withEnv("AXONIQ_AXONSERVER_NAME", "axonserver")

--- a/src/test/java/io/axoniq/axonserver/connector/event/EventHandlingIntegrationTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/event/EventHandlingIntegrationTest.java
@@ -228,7 +228,7 @@ class EventHandlingIntegrationTest extends AbstractAxonServerIntegrationTest {
     @Test
     void testScheduleAndCancel() throws Exception {
         assumeTrue(
-                axonServerVersion.matches("4\\.[4-9].*"),
+                axonServerVersion.matches("20[0-9]{2}.*") || axonServerVersion.matches("4\\.[4-9].*"),
                 "Version " + axonServerVersion + " does not support scheduled events"
         );
 
@@ -246,7 +246,7 @@ class EventHandlingIntegrationTest extends AbstractAxonServerIntegrationTest {
     @Test
     void testCancelUnknownToken() throws Exception {
         assumeTrue(
-                axonServerVersion.matches("4\\.[4-9].*"),
+                axonServerVersion.matches("20[0-9]{2}.*") || axonServerVersion.matches("4\\.[4-9].*"),
                 "Version " + axonServerVersion + " does not support scheduled events"
         );
 

--- a/src/test/java/io/axoniq/axonserver/connector/impl/AxonServerManagedChannelIntegrationTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/impl/AxonServerManagedChannelIntegrationTest.java
@@ -25,13 +25,10 @@ import io.grpc.ConnectivityState;
 import io.grpc.ManagedChannel;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
-import io.grpc.netty.NettyChannelBuilder;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import io.grpc.stub.ClientResponseObserver;
 import io.grpc.stub.StreamObserver;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.RepeatedTest;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 
@@ -219,6 +216,7 @@ class AxonServerManagedChannelIntegrationTest extends AbstractAxonServerIntegrat
         assertEquals(ConnectivityState.READY, testSubject.getState(false));
     }
 
+    @Disabled("Not forcing platform reconnects does not ensure reconnects don't happen via platform servers")
     @RepeatedTest(20)
     void sameConnectionRecoveredOnDisconnectionWithoutForcedPlatformReconnect() throws Exception {
         testSubject = new AxonServerManagedChannel(asList(new ServerAddress("server1"),

--- a/src/test/java/io/axoniq/axonserver/connector/impl/AxonServerManagedChannelIntegrationTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/impl/AxonServerManagedChannelIntegrationTest.java
@@ -216,7 +216,6 @@ class AxonServerManagedChannelIntegrationTest extends AbstractAxonServerIntegrat
         assertEquals(ConnectivityState.READY, testSubject.getState(false));
     }
 
-    @Disabled("Not forcing platform reconnects does not ensure reconnects don't happen via platform servers")
     @RepeatedTest(20)
     void sameConnectionRecoveredOnDisconnectionWithoutForcedPlatformReconnect() throws Exception {
         testSubject = new AxonServerManagedChannel(asList(new ServerAddress("server1"),
@@ -260,6 +259,7 @@ class AxonServerManagedChannelIntegrationTest extends AbstractAxonServerIntegrat
         axonServerProxy.enable();
         connectAttempts.clear();
 
+        testSubject.enterIdle();
         assertWithin(1, TimeUnit.SECONDS, () -> {
             // because we want the test to re-attempt in quick succession, we must avoid underlying connect backoff
             testSubject.resetConnectBackoff();


### PR DESCRIPTION
The connector is too reliant on a specific combination of dependencies from grpc, netty and tcnative. Changing these dependencies ensures full compatibility, regardless of dependencies introduced by other libraries (e.g. Spring Boot).

This does, unfortunately, introduce a small API change. Some components have their package prefixed, such as the SSLContext. This may cause some usage of the connector to break, although the fix is very straightforward.

This PR also addresses some tests that were running against older versions of Axon Server