### PR TITLE
Updated grpc to 1.69.0 and protobuf to 4.29.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,8 @@
 
         <axonserver.api.version>2024.1.0</axonserver.api.version>
 
-        <grpc.version>1.65.1</grpc.version>
+        <grpc.version>1.69.0</grpc.version>
+        <protobuf.version>4.29.2</protobuf.version>
 
         <slf4j.version>1.7.36</slf4j.version>
         <log4j.version>2.23.1</log4j.version>
@@ -81,6 +82,11 @@
                 <version>${grpc.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>${protobuf.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
@@ -330,9 +336,9 @@
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <version>0.6.1</version>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.6.1:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.19.0:exe:${os.detected.classifier}</pluginArtifact>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
                     <protoSourceRoot>${project.build.directory}/proto</protoSourceRoot>
                 </configuration>
                 <executions>


### PR DESCRIPTION
grpc doesn't transitively update protobuf beyond 3.x, so these have to be overridden explicitly for the time being.

I also ensured the protobug generator uses the same version as the protobuf library, to ensure any code optimizations are part of the generated code.