### PR TITLE
PersistentStreams should be re-established on reconnect requests

### DIFF
--- a/src/main/java/io/axoniq/axonserver/connector/event/impl/BufferedPersistentStreamSegment.java
+++ b/src/main/java/io/axoniq/axonserver/connector/event/impl/BufferedPersistentStreamSegment.java
@@ -113,7 +113,6 @@ public class BufferedPersistentStreamSegment
 
     @Override
     public void close() {
-        super.close();
         if (closed.compareAndSet(false, true)) {
             logger.info("{}: Close segment {}", streamId, segment);
             localOnAvailableCallback.run();

--- a/src/main/java/io/axoniq/axonserver/connector/event/impl/EventChannelImpl.java
+++ b/src/main/java/io/axoniq/axonserver/connector/event/impl/EventChannelImpl.java
@@ -129,18 +129,20 @@ public class EventChannelImpl extends AbstractAxonServerChannel<Void> implements
     @Override
     public void reconnect() {
         closeEventStreams();
+        persistedEventStreams.forEach(PersistentStreamImpl::triggerReconnect);
+        persistedEventStreams.clear();
     }
 
     @Override
     public void disconnect() {
         closeEventStreams();
+        persistedEventStreams.forEach(PersistentStreamImpl::close);
+        persistedEventStreams.clear();
     }
 
     private void closeEventStreams() {
         buffers.forEach(BufferedEventStream::close);
         buffers.clear();
-        persistedEventStreams.forEach(PersistentStreamImpl::close);
-        persistedEventStreams.clear();
     }
 
     @Override

--- a/src/main/java/io/axoniq/axonserver/connector/event/impl/PersistentStreamImpl.java
+++ b/src/main/java/io/axoniq/axonserver/connector/event/impl/PersistentStreamImpl.java
@@ -125,6 +125,11 @@ public class PersistentStreamImpl
         outboundStreamHolder.get().onNext(StreamRequest.newBuilder().setOpen(openRequest.build()).build());
     }
 
+    /**
+     * Close this stream and signal downstream consumer that the stream is closed "erroneously" in order to trigger
+     * reconnect mechanisms. This is to ensure that consumers of this stream can distinguish between regularly closed
+     * streams, and those closed with the intent to re-establish a connection.
+     */
     public void triggerReconnect() {
         // first, close gracefully
         close();


### PR DESCRIPTION
By reporting an error to downstream consumers, they are notified of the fact that the disconnect didn't happen for normal reasons, and the stream should be reopened if the application wishes to continue processing events.

This avoids problems due to clients not reconnecting their persistent streams after a reconnect request from Axon Server. Applications need to be restarted to recover from this situation.

With this PR, clients are notified of the disconnect and may re-establish a connection.