### PR TITLE
Add potential optimization on AppendEvent by combining setCondition and addEvent into one call

### DIFF
--- a/src/main/java/io/axoniq/axonserver/connector/event/DcbEventChannel.java
+++ b/src/main/java/io/axoniq/axonserver/connector/event/DcbEventChannel.java
@@ -58,7 +58,7 @@ public interface DcbEventChannel {
      *                  transaction.
      * @return the transaction reference onto which to register events to append
      */
-    AppendEventsTransaction startTransaction(ConsistencyCondition condition);
+    AppendEventsTransaction startTransaction(ConsistencyCondition condition) throws IllegalStateException;
 
     /**
      * Opens an infinite stream of events, for sequentially consuming events from Axon Server, using the given
@@ -173,6 +173,17 @@ public interface DcbEventChannel {
          * @return this Transaction for fluency
          */
         AppendEventsTransaction append(TaggedEvent taggedEvent);
+
+        /**
+         * Appends this {@code taggedEvent} with {@code condition} to this transaction.
+         * Only valid if no consistency condition was supplied before
+         *
+         * @param taggedEvent the event to be appended
+         * @param condition the consistency condition
+         * @throws IllegalStateException Will throw an IllegalStateException if Consistency Condition is already set.
+         * @return this Transaction for fluency
+         */
+        AppendEventsTransaction append(TaggedEvent taggedEvent, ConsistencyCondition condition) throws IllegalStateException;
 
         /**
          * Appends all events from the collection of {@code taggedEvents} to this transaction

--- a/src/test/docker/toxi-axonserver.yml
+++ b/src/test/docker/toxi-axonserver.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   axonserver:
-    image: axoniq/axonserver
+    image: docker.io/axoniq/axonserver
     hostname: axonserver
     environment:
       - AXONIQ_AXONSERVER_NAME=axonserver
@@ -15,7 +15,7 @@ services:
       - axonserver-eventstore:/eventdata
 
   toxiproxy:
-    image: shopify/toxiproxy
+    image: docker.io/shopify/toxiproxy
     hostname: toxiproxy
     ports:
       - '8474:8474'

--- a/src/test/java/io/axoniq/axonserver/connector/event/dcb/DcbEndToEndTest.java
+++ b/src/test/java/io/axoniq/axonserver/connector/event/dcb/DcbEndToEndTest.java
@@ -902,8 +902,8 @@ class DcbEndToEndTest extends AbstractAxonServerIntegrationTest {
     private CompletableFuture<AppendEventsResponse> appendEventAsync(TaggedEvent taggedEvent,
                                                                      ConsistencyCondition condition) {
         return connection.dcbEventChannel()
-                         .startTransaction(condition)
-                         .append(taggedEvent)
+                         .startTransaction()
+                         .append(taggedEvent, condition)
                          .commit();
     }
 }


### PR DESCRIPTION
This PR will allow a consistency condition to be sent at the same time as an event. Since this is already possible according to the protobuf API, it should be possible in axonserver-connector-java as well. It could serve as a possible optimization as it should save one round-trip in the communication with Axon Server