### PR TITLE
Connector must invoke callback on registration error

### DIFF
--- a/src/main/java/io/axoniq/axonserver/connector/Registration.java
+++ b/src/main/java/io/axoniq/axonserver/connector/Registration.java
@@ -16,19 +16,21 @@
 
 package io.axoniq.axonserver.connector;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
 
 /**
- * Interface describing an instruction to perform a registration, which can be cancelled.
+ * Interface describing an instruction to perform a registration, which can be canceled.
  */
 @FunctionalInterface
 public interface Registration {
 
     /**
      * Cancel the registration from which this instance was returned. Does nothing if the registration has already been
-     * cancelled, or when the registration was undone by another mechanism (such as a new registration overriding this
+     * canceled, or when the registration was undone by another mechanism (such as a new registration overriding this
      * one).
      *
      * @return a {@link CompletableFuture} of {@link Void} to react when {@code this} {@link Registration} has been
@@ -44,7 +46,7 @@ public interface Registration {
      * @param timeout the duration to wait until the operation has been acknowledged
      * @param unit    the {@link TimeUnit} for the given {@code timeout} to wait until the operation has been
      *                acknowledged
-     * @return {@code this} {@link Registration} to support a fluent API
+     * @return this Registration to support a fluent API
      * @throws TimeoutException     is thrown when the given {@code timeout} and {@code unit} is surpassed
      * @throws InterruptedException is thrown when the thread waiting for the acknowledgement is interrupted
      */
@@ -56,13 +58,31 @@ public interface Registration {
      * Registers the given {@code runnable} to {@code this} {@link Registration} to be executed when the acknowledgement
      * of {@code this} {@link Registration} is received. Allows for the addition of further logic to {@code this
      * Registration}, like invoking {@link #awaitAck(long, TimeUnit)} for example.
+     * <p/>
+     * The given {@code runnable} is invoked, regardless of successful or failed acknowledgement. Use
+     * {@link #onAck(Consumer)} to register an action that needs to distinguish between successful and failed
+     * registration.
      *
      * @param runnable the {@link Runnable} to execute when the acknowledgement of {@code this} {@link Registration} is
      *                 received
-     * @return {@code this} {@link Registration} to support a fluent API
+     * @return this Registration to support a fluent API
      */
     default Registration onAck(Runnable runnable) {
         runnable.run();
+        return this;
+    }
+
+    /**
+     * Registers the given {@code runnable} to {@code this} {@link Registration} to be executed when the acknowledgement
+     * of {@code this} {@link Registration} is received. Allows for the addition of further logic to
+     * {@code this Registration}, like invoking {@link #awaitAck(long, TimeUnit)} for example.
+     *
+     * @param action the action to execute when the acknowledgement of {@code this} {@link Registration} is received,
+     *               either normally or exceptionally.
+     * @return this Registration to support a fluent API
+     */
+    default Registration onAck(Consumer<Optional<Throwable>> action) {
+        action.accept(Optional.empty());
         return this;
     }
 }

--- a/src/main/java/io/axoniq/axonserver/connector/impl/AsyncRegistration.java
+++ b/src/main/java/io/axoniq/axonserver/connector/impl/AsyncRegistration.java
@@ -20,10 +20,12 @@ import io.axoniq.axonserver.connector.AxonServerException;
 import io.axoniq.axonserver.connector.ErrorCategory;
 import io.axoniq.axonserver.connector.Registration;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 /**
@@ -69,7 +71,15 @@ public class AsyncRegistration implements Registration {
 
     @Override
     public Registration onAck(Runnable runnable) {
-        requestAck.thenRun(runnable);
+        requestAck.exceptionally(e -> null).thenRun(runnable);
+        return this;
+    }
+
+    @Override
+    public Registration onAck(Consumer<Optional<Throwable>> action) {
+        requestAck.thenApply(ignored -> Optional.<Throwable>empty())
+                  .exceptionally(Optional::of)
+                  .thenAccept(action);
         return this;
     }
 }


### PR DESCRIPTION
When registering a command or event handler, the returned registration should invoke any registered acknowledgement callbacks, whether that registration was successful or not. An additional callback method is added to allow distinguishing between these situations.

This issue is the root cause of AxonFramework/AxonFramework#3938