### PR TITLE
Fix Maven Central badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # AxonServer Connector for Java
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.axoniq/axonserver-connector-java/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.axoniq/axonserver-connector-java)
+
+[![Maven Central](https://img.shields.io/maven-central/v/io.axoniq/axonserver-connector-java)](https://central.sonatype.com/artifact/io.axoniq/axonserver-connector-java)
 ![Build Status](https://github.com/AxonIQ/axonserver-connector-java/workflows/AxonServer%20Connector%20Java/badge.svg?branch=master)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=AxonIQ_axonserver-connector-java&metric=alert_status&token=7f2878de3251f0b89dd985bd2fa6dff72c0a7697)](https://sonarcloud.io/dashboard?id=AxonIQ_axonserver-connector-java)
 


### PR DESCRIPTION
Same as [axon framework #3945](https://github.com/AxonFramework/AxonFramework/pull/3945): The heroku maven badge stopped working and still showed a 2024 version as latest release.

This replaces the badge with a working solution. Caveat: the EAP is ranked higher than the GA, so currently it is still not showing the correct version, but this will change with the next patch release.