### PR TITLE
Adjust handler (de)registration levels to debug

### DIFF
--- a/src/main/java/io/axoniq/axonserver/connector/command/impl/CommandChannelImpl.java
+++ b/src/main/java/io/axoniq/axonserver/connector/command/impl/CommandChannelImpl.java
@@ -257,7 +257,7 @@ public class CommandChannelImpl extends AbstractAxonServerChannel<CommandProvide
         CommandHandler commandHandler = new CommandHandler(handler, loadFactor);
         for (String commandName : commandNames) {
             commandHandlers.put(commandName, commandHandler);
-            logger.info("Registered handler for command '{}' in context '{}'", commandName, context);
+            logger.debug("Registered handler for command '{}' in context '{}'", commandName, context);
             CompletableFuture<Void> ack = sendSubscribe(commandName, loadFactor, outboundCommandStream.get());
             subscriptionResult = CompletableFuture.allOf(subscriptionResult, ack);
         }
@@ -285,7 +285,7 @@ public class CommandChannelImpl extends AbstractAxonServerChannel<CommandProvide
         CompletableFuture<Void> future = CompletableFuture.completedFuture(null);
         for (String commandName : commandNames) {
             if (commandHandlers.get(commandName) == handler) {
-                logger.info("Deregistered handler for command '{}' in context '{}'", commandName, context);
+                logger.debug("Deregistered handler for command '{}' in context '{}'", commandName, context);
                 CompletableFuture<Void> result = sendUnsubscribe(commandName, outboundCommandStream.get())
                         .thenRun(() -> commandHandlers.remove(commandName, handler));
                 future = CompletableFuture.allOf(future, result);

--- a/src/main/java/io/axoniq/axonserver/connector/query/impl/QueryChannelImpl.java
+++ b/src/main/java/io/axoniq/axonserver/connector/query/impl/QueryChannelImpl.java
@@ -319,7 +319,7 @@ public class QueryChannelImpl extends AbstractAxonServerChannel<QueryProviderOut
                                                                                 outboundQueryStream.get());
                     subscriptionResult = CompletableFuture.allOf(subscriptionResult, instructionResult);
                 }
-                logger.info("Registered handler for query '{}' in context '{}'", queryDefinition, context);
+                logger.debug("Registered handler for query '{}' in context '{}'", queryDefinition, context);
             }
         }
         return new AsyncRegistration(subscriptionResult, () -> {


### PR DESCRIPTION
This PR adjusts command and query handler (de)registration levels to debug. 
Although valuable info, it is not paramount to be shown on info level. 
Debug suffices when debugging of handler (de)registration is required, for which this was originally intended.