### PR TITLE
Upgrade the Axon Server API version to 2026.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <sonar.organization>axoniq</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
 
-        <axonserver.api.version>2026.0.0-SNAPSHOT</axonserver.api.version>
+        <axonserver.api.version>2026.0.0</axonserver.api.version>
 
         <grpc.version>1.79.0</grpc.version>
         <protobuf.version>4.34.0</protobuf.version>


### PR DESCRIPTION
This PR upgrades the Axon Server API version to 2026.0.0.